### PR TITLE
Updated hierarchy label for dc locality

### DIFF
--- a/data/859/317/79/85931779.geojson
+++ b/data/859/317/79/85931779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018427,
-    "geom:area_square_m":177311860.302392,
+    "geom:area_square_m":177311860.302526,
     "geom:bbox":"-77.119759,38.791652764,-76.9091554217,38.9959602072",
     "geom:latitude":38.904831,
     "geom:longitude":-77.016216,
@@ -18,7 +18,7 @@
     "mps:latitude":38.912167,
     "mps:longitude":-77.014681,
     "mz:categories":[],
-    "mz:hierarchy_label":0,
+    "mz:hierarchy_label":1,
     "mz:is_current":1,
     "name:ace_x_preferred":[
         "Washington"
@@ -741,7 +741,7 @@
         }
     ],
     "wof:id":85931779,
-    "wof:lastmodified":1554847618,
+    "wof:lastmodified":1557877933,
     "wof:name":"Washington",
     "wof:parent_id":1377370667,
     "wof:placetype":"locality",


### PR DESCRIPTION
Simple fix to update the `mz:hierarchy_label` property for the locality record of Washington (DC).