### PR TITLE
Update Hartford names

### DIFF
--- a/data/859/308/19/85930819.geojson
+++ b/data/859/308/19/85930819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005063,
-    "geom:area_square_m":46698892.008935,
+    "geom:area_square_m":46698892.008906,
     "geom:bbox":"-72.718019,41.72363,-72.642536,41.807568",
     "geom:latitude":41.766071,
     "geom:longitude":-72.683401,
@@ -19,7 +19,7 @@
     "mps:latitude":41.765566,
     "mps:longitude":-72.690228,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":6.0,
     "name:ara_x_preferred":[
         "\u0647\u0627\u0631\u062a\u0641\u0648\u0631\u062f"
@@ -48,10 +48,6 @@
         "Tha 'beat"
     ],
     "name:eng_x_preferred":[
-        "Canton"
-    ],
-    "name:eng_x_variant":[
-        "Canton, Town of",
         "Hartford"
     ],
     "name:epo_x_preferred":[
@@ -343,7 +339,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1527638228,
+    "wof:lastmodified":1559148754,
     "wof:megacity":1,
     "wof:name":"Hartford",
     "wof:parent_id":404495981,


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1621

The preferred name for the locality of Hanford is "Canton" and the variant name references Canton, too. This PR removes those names and flags the locality as current.

Unsure of where these names came from, but Canton is another locality within the county of Hanford, CT. No PIP required.