### PR TITLE
Update Hawks names

### DIFF
--- a/data/112/587/736/1/1125877361.geojson
+++ b/data/112/587/736/1/1125877361.geojson
@@ -16,8 +16,14 @@
     "lbl:latitude":45.30196,
     "lbl:longitude":-83.8875,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Hawks"
+    ],
+    "name:eng_x_variant":[
+        "Hawes"
+    ],
     "qs_pg:aaroncc":"US",
     "qs_pg:gn_country":"US",
     "qs_pg:gn_fcode":"PPL",
@@ -71,8 +77,8 @@
         }
     ],
     "wof:id":1125877361,
-    "wof:lastmodified":1509397814,
-    "wof:name":"Hawes",
+    "wof:lastmodified":1559154109,
+    "wof:name":"Hawks",
     "wof:parent_id":404506187,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1624

Updates the `name` and `wof:name` properties in the locality record for Hawks, Michigan. No PIP required.