### PR TITLE
Updated locality and campus point records

### DIFF
--- a/data/120/902/939/9/1209029399.geojson
+++ b/data/120/902/939/9/1209029399.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85633793
@@ -45,12 +46,14 @@
         }
     ],
     "wof:id":1209029399,
-    "wof:lastmodified":1536299896,
+    "wof:lastmodified":1559156964,
     "wof:name":"Canandaigua Manufactured Home Community",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739929
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/902/939/9/1209029399.geojson
+++ b/data/120/902/939/9/1209029399.geojson
@@ -31,7 +31,10 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85633793
+        102191575,
+        85633793,
+        85688543,
+        102082359
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -41,14 +44,17 @@
     "wof:geomhash":"1fb6f401201e86ea877a13b895f1002f",
     "wof:hierarchy":[
         {
+            "continent_id":102191575,
             "country_id":85633793,
-            "locality_id":1209029399
+            "county_id":102082359,
+            "locality_id":1209029399,
+            "region_id":85688543
         }
     ],
     "wof:id":1209029399,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168000,
     "wof:name":"Canandaigua Manufactured Home Community",
-    "wof:parent_id":85633793,
+    "wof:parent_id":102082359,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/120/963/125/1/1209631251.geojson
+++ b/data/120/963/125/1/1209631251.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85633793
@@ -45,12 +46,14 @@
         }
     ],
     "wof:id":1209631251,
-    "wof:lastmodified":1536281186,
+    "wof:lastmodified":1559156963,
     "wof:name":"Heisler Manufactured Home Park",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739859
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/963/125/1/1209631251.geojson
+++ b/data/120/963/125/1/1209631251.geojson
@@ -31,7 +31,10 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85633793
+        102191575,
+        85633793,
+        85688727,
+        102087803
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -41,14 +44,17 @@
     "wof:geomhash":"dffa9434751fc29c651030373238b78f",
     "wof:hierarchy":[
         {
+            "continent_id":102191575,
             "country_id":85633793,
-            "locality_id":1209631251
+            "county_id":102087803,
+            "locality_id":1209631251,
+            "region_id":85688727
         }
     ],
     "wof:id":1209631251,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168001,
     "wof:name":"Heisler Manufactured Home Park",
-    "wof:parent_id":85633793,
+    "wof:parent_id":102087803,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/120/963/985/3/1209639853.geojson
+++ b/data/120/963/985/3/1209639853.geojson
@@ -31,7 +31,10 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85633793
+        102191575,
+        85633793,
+        85688599,
+        102083081
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -41,14 +44,17 @@
     "wof:geomhash":"effcd8223a98822348f039dfad869f8a",
     "wof:hierarchy":[
         {
+            "continent_id":102191575,
             "country_id":85633793,
-            "locality_id":1209639853
+            "county_id":102083081,
+            "locality_id":1209639853,
+            "region_id":85688599
         }
     ],
     "wof:id":1209639853,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168003,
     "wof:name":"Walnut Ridge Manufactured Home Community",
-    "wof:parent_id":85633793,
+    "wof:parent_id":102083081,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/120/963/985/3/1209639853.geojson
+++ b/data/120/963/985/3/1209639853.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85633793
@@ -45,12 +46,14 @@
         }
     ],
     "wof:id":1209639853,
-    "wof:lastmodified":1536280919,
+    "wof:lastmodified":1559156962,
     "wof:name":"Walnut Ridge Manufactured Home Community",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739849
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/121/003/573/1/1210035731.geojson
+++ b/data/121/003/573/1/1210035731.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1210035731,
-    "wof:lastmodified":1536386578,
+    "wof:lastmodified":1559156963,
     "wof:name":"Lakeside Manufactured Home Community",
     "wof:parent_id":102086709,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739877
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/121/003/573/1/1210035731.geojson
+++ b/data/121/003/573/1/1210035731.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1210035731,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168004,
     "wof:name":"Lakeside Manufactured Home Community",
     "wof:parent_id":102086709,
     "wof:placetype":"locality",

--- a/data/122/606/911/3/1226069113.geojson
+++ b/data/122/606/911/3/1226069113.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1226069113,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168005,
     "wof:name":"Magnolia Pointe Manufactured Home Community",
     "wof:parent_id":102085585,
     "wof:placetype":"locality",

--- a/data/122/606/911/3/1226069113.geojson
+++ b/data/122/606/911/3/1226069113.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1226069113,
-    "wof:lastmodified":1536691726,
+    "wof:lastmodified":1559156963,
     "wof:name":"Magnolia Pointe Manufactured Home Community",
     "wof:parent_id":102085585,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739891
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/616/841/7/1226168417.geojson
+++ b/data/122/616/841/7/1226168417.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688555,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1226168417,
-    "wof:lastmodified":1537043258,
+    "wof:lastmodified":1559156965,
     "wof:name":"Country Hills Manufactured Home Community",
     "wof:parent_id":404502743,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739933
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/616/841/7/1226168417.geojson
+++ b/data/122/616/841/7/1226168417.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404502743,
         85633793,
+        85688555,
         102083429
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083429,
-            "localadmin_id":404502743,
             "locality_id":1226168417,
             "region_id":85688555
         }
     ],
     "wof:id":1226168417,
-    "wof:lastmodified":1559156965,
+    "wof:lastmodified":1559168005,
     "wof:name":"Country Hills Manufactured Home Community",
-    "wof:parent_id":404502743,
+    "wof:parent_id":102083429,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/122/626/711/7/1226267117.geojson
+++ b/data/122/626/711/7/1226267117.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1226267117,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168008,
     "wof:name":"Golden Pond Village Manufactured Home Community",
     "wof:parent_id":102085779,
     "wof:placetype":"locality",

--- a/data/122/626/711/7/1226267117.geojson
+++ b/data/122/626/711/7/1226267117.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1226267117,
-    "wof:lastmodified":1536902978,
+    "wof:lastmodified":1559156964,
     "wof:name":"Golden Pond Village Manufactured Home Community",
     "wof:parent_id":102085779,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739917
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/636/213/3/1226362133.geojson
+++ b/data/122/636/213/3/1226362133.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688543,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1226362133,
-    "wof:lastmodified":1536766365,
+    "wof:lastmodified":1559156963,
     "wof:name":"North Star Manufactured Home Community",
     "wof:parent_id":404522103,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739869
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/636/213/3/1226362133.geojson
+++ b/data/122/636/213/3/1226362133.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522103,
         85633793,
+        85688543,
         102081819
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102081819,
-            "localadmin_id":404522103,
             "locality_id":1226362133,
             "region_id":85688543
         }
     ],
     "wof:id":1226362133,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168009,
     "wof:name":"North Star Manufactured Home Community",
-    "wof:parent_id":404522103,
+    "wof:parent_id":102081819,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/122/645/368/1/1226453681.geojson
+++ b/data/122/645/368/1/1226453681.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1226453681,
-    "wof:lastmodified":1536632538,
+    "wof:lastmodified":1559156963,
     "wof:name":"Pelican Bay Manufactured Home Community",
     "wof:parent_id":102084721,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739889
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/645/368/1/1226453681.geojson
+++ b/data/122/645/368/1/1226453681.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1226453681,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168009,
     "wof:name":"Pelican Bay Manufactured Home Community",
     "wof:parent_id":102084721,
     "wof:placetype":"locality",

--- a/data/122/645/867/7/1226458677.geojson
+++ b/data/122/645/867/7/1226458677.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688727,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1226458677,
-    "wof:lastmodified":1536624915,
+    "wof:lastmodified":1559156964,
     "wof:name":"Vikre Manufactured Home Park",
     "wof:parent_id":404514259,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739899
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/645/867/7/1226458677.geojson
+++ b/data/122/645/867/7/1226458677.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404514259,
         85633793,
+        85688727,
         102086997
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102086997,
-            "localadmin_id":404514259,
             "locality_id":1226458677,
             "region_id":85688727
         }
     ],
     "wof:id":1226458677,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168010,
     "wof:name":"Vikre Manufactured Home Park",
-    "wof:parent_id":404514259,
+    "wof:parent_id":102086997,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/122/655/121/5/1226551215.geojson
+++ b/data/122/655/121/5/1226551215.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506597,
         85633793,
+        85688599,
         102083111
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083111,
-            "localadmin_id":404506597,
             "locality_id":1226551215,
             "region_id":85688599
         }
     ],
     "wof:id":1226551215,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168013,
     "wof:name":"Loon Lake Manufactured Home Community",
-    "wof:parent_id":404506597,
+    "wof:parent_id":102083111,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/122/655/121/5/1226551215.geojson
+++ b/data/122/655/121/5/1226551215.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1226551215,
-    "wof:lastmodified":1536989291,
+    "wof:lastmodified":1559156964,
     "wof:name":"Loon Lake Manufactured Home Community",
     "wof:parent_id":404506597,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739921
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/280/372/3/1242803723.geojson
+++ b/data/124/280/372/3/1242803723.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688727,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1242803723,
-    "wof:lastmodified":1536737959,
+    "wof:lastmodified":1559156964,
     "wof:name":"Woodhaven Manufactured Home Community",
     "wof:parent_id":404515121,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739915
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/280/372/3/1242803723.geojson
+++ b/data/124/280/372/3/1242803723.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404515121,
         85633793,
+        85688727,
         102087861
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102087861,
-            "localadmin_id":404515121,
             "locality_id":1242803723,
             "region_id":85688727
         }
     ],
     "wof:id":1242803723,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168013,
     "wof:name":"Woodhaven Manufactured Home Community",
-    "wof:parent_id":404515121,
+    "wof:parent_id":102087861,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/124/308/688/1/1243086881.geojson
+++ b/data/124/308/688/1/1243086881.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1243086881,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168014,
     "wof:name":"Lucerne Lakeside Manufactured Home Community",
     "wof:parent_id":102085843,
     "wof:placetype":"locality",

--- a/data/124/308/688/1/1243086881.geojson
+++ b/data/124/308/688/1/1243086881.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1243086881,
-    "wof:lastmodified":1536825931,
+    "wof:lastmodified":1559156962,
     "wof:name":"Lucerne Lakeside Manufactured Home Community",
     "wof:parent_id":102085843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739843
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/346/568/5/1243465685.geojson
+++ b/data/124/346/568/5/1243465685.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1243465685,
-    "wof:lastmodified":1536778268,
+    "wof:lastmodified":1559156964,
     "wof:name":"Palm Garden Manufactured Home Community",
     "wof:parent_id":102085771,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739923
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/346/568/5/1243465685.geojson
+++ b/data/124/346/568/5/1243465685.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1243465685,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168015,
     "wof:name":"Palm Garden Manufactured Home Community",
     "wof:parent_id":102085771,
     "wof:placetype":"locality",

--- a/data/124/347/084/9/1243470849.geojson
+++ b/data/124/347/084/9/1243470849.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688727,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1243470849,
-    "wof:lastmodified":1536770883,
+    "wof:lastmodified":1559156962,
     "wof:name":"Gene Moen Manufactured Home Park",
     "wof:parent_id":404511415,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739831
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/347/084/9/1243470849.geojson
+++ b/data/124/347/084/9/1243470849.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404511415,
         85633793,
+        85688727,
         102087773
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102087773,
-            "localadmin_id":404511415,
             "locality_id":1243470849,
             "region_id":85688727
         }
     ],
     "wof:id":1243470849,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168017,
     "wof:name":"Gene Moen Manufactured Home Park",
-    "wof:parent_id":404511415,
+    "wof:parent_id":102087773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/125/950/314/3/1259503143.geojson
+++ b/data/125/950/314/3/1259503143.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507005,
         85633793,
+        85688599,
         102083151
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083151,
-            "localadmin_id":404507005,
             "locality_id":1259503143,
             "region_id":85688599
         }
     ],
     "wof:id":1259503143,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168018,
     "wof:name":"Silverbrook Manufactured Home Community",
-    "wof:parent_id":404507005,
+    "wof:parent_id":102083151,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/125/950/314/3/1259503143.geojson
+++ b/data/125/950/314/3/1259503143.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1259503143,
-    "wof:lastmodified":1536829601,
+    "wof:lastmodified":1559156964,
     "wof:name":"Silverbrook Manufactured Home Community",
     "wof:parent_id":404507005,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739925
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/989/547/1/1259895471.geojson
+++ b/data/125/989/547/1/1259895471.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688555,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1259895471,
-    "wof:lastmodified":1536762078,
+    "wof:lastmodified":1559156962,
     "wof:name":"Wilson Manufactured Home Park",
     "wof:parent_id":404505221,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739837
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/989/547/1/1259895471.geojson
+++ b/data/125/989/547/1/1259895471.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404505221,
         85633793,
+        85688555,
         102085325
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085325,
-            "localadmin_id":404505221,
             "locality_id":1259895471,
             "region_id":85688555
         }
     ],
     "wof:id":1259895471,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168019,
     "wof:name":"Wilson Manufactured Home Park",
-    "wof:parent_id":404505221,
+    "wof:parent_id":102085325,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/125/990/452/5/1259904525.geojson
+++ b/data/125/990/452/5/1259904525.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1259904525,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168020,
     "wof:name":"Whisperwood Manufactured Home Park",
     "wof:parent_id":102085865,
     "wof:placetype":"locality",

--- a/data/125/990/452/5/1259904525.geojson
+++ b/data/125/990/452/5/1259904525.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1259904525,
-    "wof:lastmodified":1536748693,
+    "wof:lastmodified":1559156962,
     "wof:name":"Whisperwood Manufactured Home Park",
     "wof:parent_id":102085865,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739845
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/623/936/1/1276239361.geojson
+++ b/data/127/623/936/1/1276239361.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/Phoenix",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1276239361,
-    "wof:lastmodified":1536904656,
+    "wof:lastmodified":1559156962,
     "wof:name":"Meridian Manufactured Home Park",
     "wof:parent_id":102081547,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739851
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/623/936/1/1276239361.geojson
+++ b/data/127/623/936/1/1276239361.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1276239361,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168022,
     "wof:name":"Meridian Manufactured Home Park",
     "wof:parent_id":102081547,
     "wof:placetype":"locality",

--- a/data/127/624/805/3/1276248053.geojson
+++ b/data/127/624/805/3/1276248053.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1276248053,
-    "wof:lastmodified":1536892652,
+    "wof:lastmodified":1559156963,
     "wof:name":"Parkwood Manufactured Home Community",
     "wof:parent_id":102085865,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739857
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/624/805/3/1276248053.geojson
+++ b/data/127/624/805/3/1276248053.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1276248053,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168023,
     "wof:name":"Parkwood Manufactured Home Community",
     "wof:parent_id":102085865,
     "wof:placetype":"locality",

--- a/data/127/635/587/3/1276355873.geojson
+++ b/data/127/635/587/3/1276355873.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/Los_Angeles",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1276355873,
-    "wof:lastmodified":1536748201,
+    "wof:lastmodified":1559156963,
     "wof:name":"Island Park Manufactured Home Park",
     "wof:parent_id":102087543,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739875
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/635/587/3/1276355873.geojson
+++ b/data/127/635/587/3/1276355873.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1276355873,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168024,
     "wof:name":"Island Park Manufactured Home Park",
     "wof:parent_id":102087543,
     "wof:placetype":"locality",

--- a/data/127/645/430/1/1276454301.geojson
+++ b/data/127/645/430/1/1276454301.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506085,
         85633793,
+        85688599,
         102083671
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083671,
-            "localadmin_id":404506085,
             "locality_id":1276454301,
             "region_id":85688599
         }
     ],
     "wof:id":1276454301,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168025,
     "wof:name":"Wyngate Farms Manufactured Home Community",
-    "wof:parent_id":404506085,
+    "wof:parent_id":102083671,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/127/645/430/1/1276454301.geojson
+++ b/data/127/645/430/1/1276454301.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1276454301,
-    "wof:lastmodified":1536614158,
+    "wof:lastmodified":1559156964,
     "wof:name":"Wyngate Farms Manufactured Home Community",
     "wof:parent_id":404506085,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739905
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/678/310/3/1276783103.geojson
+++ b/data/127/678/310/3/1276783103.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1276783103,
-    "wof:lastmodified":1536673248,
+    "wof:lastmodified":1559156962,
     "wof:name":"Sunshine Village Manufactured Home Community",
     "wof:parent_id":102085855,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739839
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/678/310/3/1276783103.geojson
+++ b/data/127/678/310/3/1276783103.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1276783103,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168027,
     "wof:name":"Sunshine Village Manufactured Home Community",
     "wof:parent_id":102085855,
     "wof:placetype":"locality",

--- a/data/127/690/976/5/1276909765.geojson
+++ b/data/127/690/976/5/1276909765.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506281,
         85633793,
+        85688599,
         102083117
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083117,
-            "localadmin_id":404506281,
             "locality_id":1276909765,
             "region_id":85688599
         }
     ],
     "wof:id":1276909765,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168028,
     "wof:name":"Hidden Creek Manufactured Home Community",
-    "wof:parent_id":404506281,
+    "wof:parent_id":102083117,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/127/690/976/5/1276909765.geojson
+++ b/data/127/690/976/5/1276909765.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1276909765,
-    "wof:lastmodified":1537000435,
+    "wof:lastmodified":1559156963,
     "wof:name":"Hidden Creek Manufactured Home Community",
     "wof:parent_id":404506281,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739885
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/700/157/1/1277001571.geojson
+++ b/data/127/700/157/1/1277001571.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506085,
         85633793,
+        85688599,
         102083671
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083671,
-            "localadmin_id":404506085,
             "locality_id":1277001571,
             "region_id":85688599
         }
     ],
     "wof:id":1277001571,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168029,
     "wof:name":"Saddlebrook Farms Manufactured Home Community",
-    "wof:parent_id":404506085,
+    "wof:parent_id":102083671,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/127/700/157/1/1277001571.geojson
+++ b/data/127/700/157/1/1277001571.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1277001571,
-    "wof:lastmodified":1536877257,
+    "wof:lastmodified":1559156964,
     "wof:name":"Saddlebrook Farms Manufactured Home Community",
     "wof:parent_id":404506085,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739907
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/330/904/1/1293309041.geojson
+++ b/data/129/330/904/1/1293309041.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404502889,
         85633793,
+        85688555,
         102084179
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084179,
-            "localadmin_id":404502889,
             "locality_id":1293309041,
             "region_id":85688555
         }
     ],
     "wof:id":1293309041,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168030,
     "wof:name":"Redbud Estates Manufactured Home Community",
-    "wof:parent_id":404502889,
+    "wof:parent_id":102084179,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/129/330/904/1/1293309041.geojson
+++ b/data/129/330/904/1/1293309041.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688555,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1293309041,
-    "wof:lastmodified":1537042536,
+    "wof:lastmodified":1559156963,
     "wof:name":"Redbud Estates Manufactured Home Community",
     "wof:parent_id":404502889,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739873
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/340/573/5/1293405735.geojson
+++ b/data/129/340/573/5/1293405735.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1293405735,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168032,
     "wof:name":"Park Place Estates Manufactured Home Park",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",

--- a/data/129/340/573/5/1293405735.geojson
+++ b/data/129/340/573/5/1293405735.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/Los_Angeles",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1293405735,
-    "wof:lastmodified":1536905027,
+    "wof:lastmodified":1559156964,
     "wof:name":"Park Place Estates Manufactured Home Park",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739913
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/341/596/1/1293415961.geojson
+++ b/data/129/341/596/1/1293415961.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688555,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1293415961,
-    "wof:lastmodified":1536889878,
+    "wof:lastmodified":1559156964,
     "wof:name":"Lakeside Manufactured Home Community",
     "wof:parent_id":404504929,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739897
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/341/596/1/1293415961.geojson
+++ b/data/129/341/596/1/1293415961.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404504929,
         85633793,
+        85688555,
         102084203
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084203,
-            "localadmin_id":404504929,
             "locality_id":1293415961,
             "region_id":85688555
         }
     ],
     "wof:id":1293415961,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168033,
     "wof:name":"Lakeside Manufactured Home Community",
-    "wof:parent_id":404504929,
+    "wof:parent_id":102084203,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/129/342/643/7/1293426437.geojson
+++ b/data/129/342/643/7/1293426437.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1293426437,
-    "wof:lastmodified":1536874002,
+    "wof:lastmodified":1559156963,
     "wof:name":"Pleasant Ridge Manufactured Home Community",
     "wof:parent_id":404507765,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739871
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/342/643/7/1293426437.geojson
+++ b/data/129/342/643/7/1293426437.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507765,
         85633793,
+        85688599,
         102083065
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083065,
-            "localadmin_id":404507765,
             "locality_id":1293426437,
             "region_id":85688599
         }
     ],
     "wof:id":1293426437,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168034,
     "wof:name":"Pleasant Ridge Manufactured Home Community",
-    "wof:parent_id":404507765,
+    "wof:parent_id":102083065,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/129/350/703/1/1293507031.geojson
+++ b/data/129/350/703/1/1293507031.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688697,
@@ -52,12 +53,14 @@
         }
     ],
     "wof:id":1293507031,
-    "wof:lastmodified":1536759065,
+    "wof:lastmodified":1559156963,
     "wof:name":"Paradise Acres Manufactured Home Community",
     "wof:parent_id":404499233,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739861
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/350/703/1/1293507031.geojson
+++ b/data/129/350/703/1/1293507031.geojson
@@ -30,10 +30,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688697,
         102191575,
-        404499233,
         85633793,
+        85688697,
         102084325
     ],
     "wof:breaches":[],
@@ -47,15 +46,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084325,
-            "localadmin_id":404499233,
             "locality_id":1293507031,
             "region_id":85688697
         }
     ],
     "wof:id":1293507031,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168035,
     "wof:name":"Paradise Acres Manufactured Home Community",
-    "wof:parent_id":404499233,
+    "wof:parent_id":102084325,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/130/992/172/7/1309921727.geojson
+++ b/data/130/992/172/7/1309921727.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1309921727,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168037,
     "wof:name":"River Villas Manufactured Home Park",
     "wof:parent_id":102085849,
     "wof:placetype":"locality",

--- a/data/130/992/172/7/1309921727.geojson
+++ b/data/130/992/172/7/1309921727.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1309921727,
-    "wof:lastmodified":1536764297,
+    "wof:lastmodified":1559156962,
     "wof:name":"River Villas Manufactured Home Park",
     "wof:parent_id":102085849,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739855
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/993/136/5/1309931365.geojson
+++ b/data/130/993/136/5/1309931365.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522863,
         85633793,
+        85688543,
         102082359
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102082359,
-            "localadmin_id":404522863,
             "locality_id":1309931365,
             "region_id":85688543
         }
     ],
     "wof:id":1309931365,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168038,
     "wof:name":"Farmington Manufactured Home Community",
-    "wof:parent_id":404522863,
+    "wof:parent_id":102082359,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/130/993/136/5/1309931365.geojson
+++ b/data/130/993/136/5/1309931365.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688543,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1309931365,
-    "wof:lastmodified":1536750067,
+    "wof:lastmodified":1559156964,
     "wof:name":"Farmington Manufactured Home Community",
     "wof:parent_id":404522863,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739903
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/012/550/5/1310125505.geojson
+++ b/data/131/012/550/5/1310125505.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688697,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1310125505,
-    "wof:lastmodified":1536967389,
+    "wof:lastmodified":1559156962,
     "wof:name":"Family Manufactured Home Community",
     "wof:parent_id":404499349,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739835
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/012/550/5/1310125505.geojson
+++ b/data/131/012/550/5/1310125505.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688697,
         102191575,
-        404499349,
         85633793,
+        85688697,
         102080827
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102080827,
-            "localadmin_id":404499349,
             "locality_id":1310125505,
             "region_id":85688697
         }
     ],
     "wof:id":1310125505,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168039,
     "wof:name":"Family Manufactured Home Community",
-    "wof:parent_id":404499349,
+    "wof:parent_id":102080827,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/131/013/030/3/1310130303.geojson
+++ b/data/131/013/030/3/1310130303.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688543,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1310130303,
-    "wof:lastmodified":1536960670,
+    "wof:lastmodified":1559156964,
     "wof:name":"Sunset Valley Manufactured Home Community",
     "wof:parent_id":404522657,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739909
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/013/030/3/1310130303.geojson
+++ b/data/131/013/030/3/1310130303.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522657,
         85633793,
+        85688543,
         102081815
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102081815,
-            "localadmin_id":404522657,
             "locality_id":1310130303,
             "region_id":85688543
         }
     ],
     "wof:id":1310130303,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168041,
     "wof:name":"Sunset Valley Manufactured Home Community",
-    "wof:parent_id":404522657,
+    "wof:parent_id":102081815,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/131/022/422/3/1310224223.geojson
+++ b/data/131/022/422/3/1310224223.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1310224223,
-    "wof:lastmodified":1536824346,
+    "wof:lastmodified":1559156964,
     "wof:name":"Ortega Village Manufactured Home Community",
     "wof:parent_id":102084753,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739911
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/022/422/3/1310224223.geojson
+++ b/data/131/022/422/3/1310224223.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1310224223,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168042,
     "wof:name":"Ortega Village Manufactured Home Community",
     "wof:parent_id":102084753,
     "wof:placetype":"locality",

--- a/data/131/041/690/1/1310416901.geojson
+++ b/data/131/041/690/1/1310416901.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688555,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1310416901,
-    "wof:lastmodified":1537043002,
+    "wof:lastmodified":1559156962,
     "wof:name":"Applewood Meadows Manufactured Home Community",
     "wof:parent_id":404504767,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739841
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/041/690/1/1310416901.geojson
+++ b/data/131/041/690/1/1310416901.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404504767,
         85633793,
+        85688555,
         102082171
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102082171,
-            "localadmin_id":404504767,
             "locality_id":1310416901,
             "region_id":85688555
         }
     ],
     "wof:id":1310416901,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168044,
     "wof:name":"Applewood Meadows Manufactured Home Community",
-    "wof:parent_id":404504767,
+    "wof:parent_id":102082171,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/132/665/443/3/1326654433.geojson
+++ b/data/132/665/443/3/1326654433.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1326654433,
-    "wof:lastmodified":1536807589,
+    "wof:lastmodified":1559156964,
     "wof:name":"Maple Woods Manufactured Home Community",
     "wof:parent_id":404507379,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739895
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/665/443/3/1326654433.geojson
+++ b/data/132/665/443/3/1326654433.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507379,
         85633793,
+        85688599,
         102083099
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083099,
-            "localadmin_id":404507379,
             "locality_id":1326654433,
             "region_id":85688599
         }
     ],
     "wof:id":1326654433,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168045,
     "wof:name":"Maple Woods Manufactured Home Community",
-    "wof:parent_id":404507379,
+    "wof:parent_id":102083099,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/132/694/987/3/1326949873.geojson
+++ b/data/132/694/987/3/1326949873.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688543,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1326949873,
-    "wof:lastmodified":1536878647,
+    "wof:lastmodified":1559156964,
     "wof:name":"Lakeview Manufactured Home Community",
     "wof:parent_id":404522861,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739927
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/694/987/3/1326949873.geojson
+++ b/data/132/694/987/3/1326949873.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522861,
         85633793,
+        85688543,
         102082359
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102082359,
-            "localadmin_id":404522861,
             "locality_id":1326949873,
             "region_id":85688543
         }
     ],
     "wof:id":1326949873,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168047,
     "wof:name":"Lakeview Manufactured Home Community",
-    "wof:parent_id":404522861,
+    "wof:parent_id":102082359,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/132/696/451/9/1326964519.geojson
+++ b/data/132/696/451/9/1326964519.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1326964519,
-    "wof:lastmodified":1536857078,
+    "wof:lastmodified":1559156963,
     "wof:name":"Windham Hill Manufactured Home Community",
     "wof:parent_id":404507769,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739867
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/696/451/9/1326964519.geojson
+++ b/data/132/696/451/9/1326964519.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507769,
         85633793,
+        85688599,
         102083081
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083081,
-            "localadmin_id":404507769,
             "locality_id":1326964519,
             "region_id":85688599
         }
     ],
     "wof:id":1326964519,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168048,
     "wof:name":"Windham Hill Manufactured Home Community",
-    "wof:parent_id":404507769,
+    "wof:parent_id":102083081,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/132/704/632/5/1327046325.geojson
+++ b/data/132/704/632/5/1327046325.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/Los_Angeles",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1327046325,
-    "wof:lastmodified":1536740179,
+    "wof:lastmodified":1559156963,
     "wof:name":"Royal Oak Manufactured Home Community",
     "wof:parent_id":102082309,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739887
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/704/632/5/1327046325.geojson
+++ b/data/132/704/632/5/1327046325.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1327046325,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168049,
     "wof:name":"Royal Oak Manufactured Home Community",
     "wof:parent_id":102082309,
     "wof:placetype":"locality",

--- a/data/132/735/944/3/1327359443.geojson
+++ b/data/132/735/944/3/1327359443.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688727,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1327359443,
-    "wof:lastmodified":1536786749,
+    "wof:lastmodified":1559156965,
     "wof:name":"Country Lane Manufactured Home Park",
     "wof:parent_id":404511371,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739931
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/735/944/3/1327359443.geojson
+++ b/data/132/735/944/3/1327359443.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404511371,
         85633793,
+        85688727,
         102087773
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102087773,
-            "localadmin_id":404511371,
             "locality_id":1327359443,
             "region_id":85688727
         }
     ],
     "wof:id":1327359443,
-    "wof:lastmodified":1559156965,
+    "wof:lastmodified":1559168050,
     "wof:name":"Country Lane Manufactured Home Park",
-    "wof:parent_id":404511371,
+    "wof:parent_id":102087773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/134/328/171/1/1343281711.geojson
+++ b/data/134/328/171/1/1343281711.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688555,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1343281711,
-    "wof:lastmodified":1537003528,
+    "wof:lastmodified":1559156962,
     "wof:name":"Parkwood Court Manufactured Home Park",
     "wof:parent_id":404504467,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739833
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/328/171/1/1343281711.geojson
+++ b/data/134/328/171/1/1343281711.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404504467,
         85633793,
+        85688555,
         102083429
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083429,
-            "localadmin_id":404504467,
             "locality_id":1343281711,
             "region_id":85688555
         }
     ],
     "wof:id":1343281711,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168052,
     "wof:name":"Parkwood Court Manufactured Home Park",
-    "wof:parent_id":404504467,
+    "wof:parent_id":102083429,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/134/337/549/9/1343375499.geojson
+++ b/data/134/337/549/9/1343375499.geojson
@@ -31,10 +31,9 @@
     "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404505647,
         85633793,
+        85688599,
         102083111
     ],
     "wof:breaches":[],
@@ -48,15 +47,14 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083111,
-            "localadmin_id":404505647,
             "locality_id":1343375499,
             "region_id":85688599
         }
     ],
     "wof:id":1343375499,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168053,
     "wof:name":"Orchard Cove Manufactured Home Community",
-    "wof:parent_id":404505647,
+    "wof:parent_id":102083111,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[

--- a/data/134/337/549/9/1343375499.geojson
+++ b/data/134/337/549/9/1343375499.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Detroit",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         85688599,
@@ -53,12 +54,14 @@
         }
     ],
     "wof:id":1343375499,
-    "wof:lastmodified":1536867580,
+    "wof:lastmodified":1559156962,
     "wof:name":"Orchard Cove Manufactured Home Community",
     "wof:parent_id":404505647,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739827
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/357/765/1/1343577651.geojson
+++ b/data/134/357/765/1/1343577651.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1343577651,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168054,
     "wof:name":"Mountain Meadows Manufactured Home Community",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",

--- a/data/134/357/765/1/1343577651.geojson
+++ b/data/134/357/765/1/1343577651.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/Los_Angeles",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1343577651,
-    "wof:lastmodified":1537071577,
+    "wof:lastmodified":1559156963,
     "wof:name":"Mountain Meadows Manufactured Home Community",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739863
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/397/384/1/1343973841.geojson
+++ b/data/134/397/384/1/1343973841.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1343973841,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168055,
     "wof:name":"Cobb's Manufactured Home Park",
     "wof:parent_id":102086687,
     "wof:placetype":"locality",

--- a/data/134/397/384/1/1343973841.geojson
+++ b/data/134/397/384/1/1343973841.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1343973841,
-    "wof:lastmodified":1536999918,
+    "wof:lastmodified":1559156963,
     "wof:name":"Cobb's Manufactured Home Park",
     "wof:parent_id":102086687,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739881
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/418/153/1/1344181531.geojson
+++ b/data/134/418/153/1/1344181531.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1344181531,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168057,
     "wof:name":"Riverview Manufactured Home Community",
     "wof:parent_id":102084721,
     "wof:placetype":"locality",

--- a/data/134/418/153/1/1344181531.geojson
+++ b/data/134/418/153/1/1344181531.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1344181531,
-    "wof:lastmodified":1536701182,
+    "wof:lastmodified":1559156963,
     "wof:name":"Riverview Manufactured Home Community",
     "wof:parent_id":102084721,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739879
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/136/019/561/5/1360195615.geojson
+++ b/data/136/019/561/5/1360195615.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -27,7 +28,7 @@
     "gn:timezone":"America/Chicago",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -51,12 +52,14 @@
         }
     ],
     "wof:id":1360195615,
-    "wof:lastmodified":1536786637,
+    "wof:lastmodified":1559156964,
     "wof:name":"Five Seasons Manufactured Home Community",
     "wof:parent_id":102086551,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739893
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/136/019/561/5/1360195615.geojson
+++ b/data/136/019/561/5/1360195615.geojson
@@ -52,7 +52,7 @@
         }
     ],
     "wof:id":1360195615,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168058,
     "wof:name":"Five Seasons Manufactured Home Community",
     "wof:parent_id":102086551,
     "wof:placetype":"locality",

--- a/data/136/030/461/7/1360304617.geojson
+++ b/data/136/030/461/7/1360304617.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-05-29",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -26,7 +27,7 @@
     "gn:timezone":"America/New_York",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -50,12 +51,14 @@
         }
     ],
     "wof:id":1360304617,
-    "wof:lastmodified":1536627173,
+    "wof:lastmodified":1559156962,
     "wof:name":"Magnolia Circle Manufactured Home Community",
     "wof:parent_id":102084753,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1393739853
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/136/030/461/7/1360304617.geojson
+++ b/data/136/030/461/7/1360304617.geojson
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":1360304617,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168059,
     "wof:name":"Magnolia Circle Manufactured Home Community",
     "wof:parent_id":102084753,
     "wof:placetype":"locality",

--- a/data/137/689/925/5/1376899255.geojson
+++ b/data/137/689/925/5/1376899255.geojson
@@ -31,7 +31,6 @@
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
-        404514259,
         85633793,
         102086997,
         85688727
@@ -48,14 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102086997,
-            "localadmin_id":404514259,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688727
         }
     ],
     "wof:id":1376899255,
-    "wof:lastmodified":1549655846,
+    "wof:lastmodified":1559167891,
     "wof:name":"Harmony Mobile Home Park",
-    "wof:parent_id":404514259,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/982/7/1393739827.geojson
+++ b/data/139/373/982/7/1393739827.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739827,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-83.52889,43.16306,-83.52889,43.16306",
+    "geom:latitude":43.16306,
+    "geom:longitude":-83.52889,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"49.0",
+    "gn:admin3_code":"29420.0",
+    "gn:asciiname":"Orchard Cove Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":242,
+    "gn:elevation":"242.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7717833,
+    "gn:latitude":43.16306,
+    "gn:longitude":-83.52889,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Orchard Cove Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404505647,
+        85633793,
+        1343375499,
+        102083111
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7717833
+    },
+    "wof:country":"US",
+    "wof:geomhash":"477e6a1bf8978af0d534b0dc8a84dd55",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739827,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083111,
+            "localadmin_id":404505647,
+            "locality_id":1343375499,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739827,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Orchard Cove Manufactured Home Community",
+    "wof:parent_id":404505647,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343375499
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -83.52889,
+    43.16306,
+    -83.52889,
+    43.16306
+],
+  "geometry": {"coordinates":[-83.52889,43.16306],"type":"Point"}
+}

--- a/data/139/373/982/7/1393739827.geojson
+++ b/data/139/373/982/7/1393739827.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404505647,
         85633793,
-        1343375499,
-        102083111
+        102083111,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083111,
-            "localadmin_id":404505647,
-            "locality_id":1343375499,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739827,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168059,
     "wof:name":"Orchard Cove Manufactured Home Community",
-    "wof:parent_id":404505647,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/983/1/1393739831.geojson
+++ b/data/139/373/983/1/1393739831.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404511415,
         85633793,
-        1243470849,
-        102087773
+        102087773,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102087773,
-            "localadmin_id":404511415,
-            "locality_id":1243470849,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688727
         }
     ],
     "wof:id":1393739831,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168062,
     "wof:name":"Gene Moen Manufactured Home Park",
-    "wof:parent_id":404511415,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/983/1/1393739831.geojson
+++ b/data/139/373/983/1/1393739831.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739831,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-94.88611,47.55,-94.88611,47.55",
+    "geom:latitude":47.55,
+    "geom:longitude":-94.88611,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"007",
+    "gn:admin3_code":"46906.0",
+    "gn:asciiname":"Gene Moen Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":420,
+    "gn:elevation":"422.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7121934,
+    "gn:latitude":47.55,
+    "gn:longitude":-94.88611,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Gene Moen Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688727,
+        102191575,
+        404511415,
+        85633793,
+        1243470849,
+        102087773
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7121934
+    },
+    "wof:country":"US",
+    "wof:geomhash":"e4e30fda8cfa7ca69d0fc60aa127fcb9",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739831,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087773,
+            "localadmin_id":404511415,
+            "locality_id":1243470849,
+            "region_id":85688727
+        }
+    ],
+    "wof:id":1393739831,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Gene Moen Manufactured Home Park",
+    "wof:parent_id":404511415,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243470849
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -94.88611,
+    47.55,
+    -94.88611,
+    47.55
+],
+  "geometry": {"coordinates":[-94.88611,47.55],"type":"Point"}
+}

--- a/data/139/373/983/3/1393739833.geojson
+++ b/data/139/373/983/3/1393739833.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404504467,
         85633793,
-        1343281711,
-        102083429
+        102083429,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083429,
-            "localadmin_id":404504467,
-            "locality_id":1343281711,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688555
         }
     ],
     "wof:id":1393739833,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168062,
     "wof:name":"Parkwood Court Manufactured Home Park",
-    "wof:parent_id":404504467,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/983/3/1393739833.geojson
+++ b/data/139/373/983/3/1393739833.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739833,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-94.8963,39.25427,-94.8963,39.25427",
+    "geom:latitude":39.25427,
+    "geom:longitude":-94.8963,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"103.0",
+    "gn:admin3_code":"38650.0",
+    "gn:asciiname":"Parkwood Court Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":243,
+    "gn:elevation":"241.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8122796,
+    "gn:latitude":39.25427,
+    "gn:longitude":-94.8963,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Parkwood Court Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688555,
+        102191575,
+        404504467,
+        85633793,
+        1343281711,
+        102083429
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8122796
+    },
+    "wof:country":"US",
+    "wof:geomhash":"0d120fcc05081f131101d7ee1cf73d74",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739833,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083429,
+            "localadmin_id":404504467,
+            "locality_id":1343281711,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1393739833,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Parkwood Court Manufactured Home Park",
+    "wof:parent_id":404504467,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343281711
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -94.8963,
+    39.25427,
+    -94.8963,
+    39.25427
+],
+  "geometry": {"coordinates":[-94.8963,39.25427],"type":"Point"}
+}

--- a/data/139/373/983/5/1393739835.geojson
+++ b/data/139/373/983/5/1393739835.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739835,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-89.075,42.22444,-89.075,42.22444",
+    "geom:latitude":42.22444,
+    "geom:longitude":-89.075,
+    "gn:admin1_code":"IL",
+    "gn:admin2_code":"201.0",
+    "gn:admin3_code":"65013.0",
+    "gn:asciiname":"Family Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":224,
+    "gn:elevation":"220.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7728031,
+    "gn:latitude":42.22444,
+    "gn:longitude":-89.075,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Family Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688697,
+        102191575,
+        404499349,
+        85633793,
+        1310125505,
+        102080827
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7728031
+    },
+    "wof:country":"US",
+    "wof:geomhash":"9bd0b897a03069534fc04d029b19a8b8",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739835,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102080827,
+            "localadmin_id":404499349,
+            "locality_id":1310125505,
+            "region_id":85688697
+        }
+    ],
+    "wof:id":1393739835,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Family Manufactured Home Community",
+    "wof:parent_id":404499349,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310125505
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -89.075,
+    42.22444,
+    -89.075,
+    42.22444
+],
+  "geometry": {"coordinates":[-89.075,42.22444],"type":"Point"}
+}

--- a/data/139/373/983/5/1393739835.geojson
+++ b/data/139/373/983/5/1393739835.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688697,
         102191575,
-        404499349,
         85633793,
-        1310125505,
-        102080827
+        102080827,
+        85688697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102080827,
-            "localadmin_id":404499349,
-            "locality_id":1310125505,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688697
         }
     ],
     "wof:id":1393739835,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168063,
     "wof:name":"Family Manufactured Home Community",
-    "wof:parent_id":404499349,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/983/7/1393739837.geojson
+++ b/data/139/373/983/7/1393739837.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404505221,
         85633793,
-        1259895471,
-        102085325
+        102085325,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085325,
-            "localadmin_id":404505221,
-            "locality_id":1259895471,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688555
         }
     ],
     "wof:id":1393739837,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168064,
     "wof:name":"Wilson Manufactured Home Park",
-    "wof:parent_id":404505221,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/983/7/1393739837.geojson
+++ b/data/139/373/983/7/1393739837.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739837,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-97.63819,37.39392,-97.63819,37.39392",
+    "geom:latitude":37.39392,
+    "geom:longitude":-97.63819,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"191.0",
+    "gn:admin3_code":"15300.0",
+    "gn:asciiname":"Wilson Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":416,
+    "gn:elevation":"413.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8122844,
+    "gn:latitude":37.39392,
+    "gn:longitude":-97.63819,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Wilson Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688555,
+        102191575,
+        404505221,
+        85633793,
+        1259895471,
+        102085325
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8122844
+    },
+    "wof:country":"US",
+    "wof:geomhash":"4834555bf77c4877226c6e6913403a43",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739837,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085325,
+            "localadmin_id":404505221,
+            "locality_id":1259895471,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1393739837,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Wilson Manufactured Home Park",
+    "wof:parent_id":404505221,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259895471
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -97.63819,
+    37.39392,
+    -97.63819,
+    37.39392
+],
+  "geometry": {"coordinates":[-97.63818999999999,37.39392],"type":"Point"}
+}

--- a/data/139/373/983/9/1393739839.geojson
+++ b/data/139/373/983/9/1393739839.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739839,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.0698,28.6086,-82.0698,28.6086",
+    "geom:latitude":28.6086,
+    "geom:longitude":-82.0698,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"119.0",
+    "gn:asciiname":"Sunshine Village Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":31,
+    "gn:elevation":"26.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7193378,
+    "gn:latitude":28.6086,
+    "gn:longitude":-82.0698,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Sunshine Village Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1276783103,
+        102085855
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7193378
+    },
+    "wof:country":"US",
+    "wof:geomhash":"fdf289ebb7fef549e282e1edafdd0b85",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739839,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085855,
+            "locality_id":1276783103,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739839,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Sunshine Village Manufactured Home Community",
+    "wof:parent_id":102085855,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276783103
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.0698,
+    28.6086,
+    -82.0698,
+    28.6086
+],
+  "geometry": {"coordinates":[-82.0698,28.6086],"type":"Point"}
+}

--- a/data/139/373/983/9/1393739839.geojson
+++ b/data/139/373/983/9/1393739839.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1276783103,
-        102085855
+        102085855,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085855,
-            "locality_id":1276783103,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739839,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168066,
     "wof:name":"Sunshine Village Manufactured Home Community",
-    "wof:parent_id":102085855,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/984/1/1393739841.geojson
+++ b/data/139/373/984/1/1393739841.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404504767,
         85633793,
-        1310416901,
-        102082171
+        102082171,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102082171,
-            "localadmin_id":404504767,
-            "locality_id":1310416901,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688555
         }
     ],
     "wof:id":1393739841,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168067,
     "wof:name":"Applewood Meadows Manufactured Home Community",
-    "wof:parent_id":404504767,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/984/1/1393739841.geojson
+++ b/data/139/373/984/1/1393739841.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739841,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-97.88895,38.0598,-97.88895,38.0598",
+    "geom:latitude":38.0598,
+    "geom:longitude":-97.88895,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"155.0",
+    "gn:admin3_code":"33625.0",
+    "gn:asciiname":"Applewood Meadows Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":474,
+    "gn:elevation":"464.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8122708,
+    "gn:latitude":38.0598,
+    "gn:longitude":-97.88895,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Applewood Meadows Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688555,
+        102191575,
+        404504767,
+        85633793,
+        1310416901,
+        102082171
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8122708
+    },
+    "wof:country":"US",
+    "wof:geomhash":"5709a7ccd8c0ecb6ee858cbbaa24bc3d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739841,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082171,
+            "localadmin_id":404504767,
+            "locality_id":1310416901,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1393739841,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Applewood Meadows Manufactured Home Community",
+    "wof:parent_id":404504767,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310416901
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -97.88895,
+    38.0598,
+    -97.88895,
+    38.0598
+],
+  "geometry": {"coordinates":[-97.88894999999999,38.0598],"type":"Point"}
+}

--- a/data/139/373/984/3/1393739843.geojson
+++ b/data/139/373/984/3/1393739843.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1243086881,
-        102085843
+        102085843,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085843,
-            "locality_id":1243086881,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739843,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168068,
     "wof:name":"Lucerne Lakeside Manufactured Home Community",
-    "wof:parent_id":102085843,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/984/3/1393739843.geojson
+++ b/data/139/373/984/3/1393739843.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739843,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.71235,28.06449,-81.71235,28.06449",
+    "geom:latitude":28.06449,
+    "geom:longitude":-81.71235,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"105.0",
+    "gn:asciiname":"Lucerne Lakeside Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":41,
+    "gn:elevation":"42.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7193488,
+    "gn:latitude":28.06449,
+    "gn:longitude":-81.71235,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Lucerne Lakeside Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1243086881,
+        102085843
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7193488
+    },
+    "wof:country":"US",
+    "wof:geomhash":"80a55b73618c42d7a06a457e69518f9d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739843,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085843,
+            "locality_id":1243086881,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739843,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Lucerne Lakeside Manufactured Home Community",
+    "wof:parent_id":102085843,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243086881
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.71235,
+    28.06449000000001,
+    -81.71235,
+    28.06449000000001
+],
+  "geometry": {"coordinates":[-81.71235,28.06449000000001],"type":"Point"}
+}

--- a/data/139/373/984/5/1393739845.geojson
+++ b/data/139/373/984/5/1393739845.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739845,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.31287,29.1021,-81.31287,29.1021",
+    "geom:latitude":29.1021,
+    "geom:longitude":-81.31287,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"127.0",
+    "gn:asciiname":"Whisperwood Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":34,
+    "gn:elevation":"26.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7190266,
+    "gn:latitude":29.1021,
+    "gn:longitude":-81.31287,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Whisperwood Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1259904525,
+        102085865
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7190266
+    },
+    "wof:country":"US",
+    "wof:geomhash":"a766a73cb2209ed23fc891135b8dc7b3",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739845,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085865,
+            "locality_id":1259904525,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739845,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Whisperwood Manufactured Home Park",
+    "wof:parent_id":102085865,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259904525
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.31286999999998,
+    29.1021,
+    -81.31286999999998,
+    29.1021
+],
+  "geometry": {"coordinates":[-81.31286999999998,29.1021],"type":"Point"}
+}

--- a/data/139/373/984/5/1393739845.geojson
+++ b/data/139/373/984/5/1393739845.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1259904525,
-        102085865
+        102085865,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085865,
-            "locality_id":1259904525,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739845,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168069,
     "wof:name":"Whisperwood Manufactured Home Park",
-    "wof:parent_id":102085865,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/984/9/1393739849.geojson
+++ b/data/139/373/984/9/1393739849.geojson
@@ -30,8 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        1209639853,
-        85633793
+        102191575,
+        85633793,
+        102083081,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -42,14 +44,18 @@
     "wof:hierarchy":[
         {
             "campus_id":1393739849,
+            "continent_id":102191575,
             "country_id":85633793,
-            "locality_id":1209639853
+            "county_id":102083081,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":85688599
         }
     ],
     "wof:id":1393739849,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168071,
     "wof:name":"Walnut Ridge Manufactured Home Community",
-    "wof:parent_id":85633793,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/984/9/1393739849.geojson
+++ b/data/139/373/984/9/1393739849.geojson
@@ -1,0 +1,68 @@
+{
+  "id": 1393739849,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-84.44694,42.2925,-84.44694,42.2925",
+    "geom:latitude":42.2925,
+    "geom:longitude":-84.44694,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"75.0",
+    "gn:admin3_code":"8760.0",
+    "gn:asciiname":"Walnut Ridge Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":295,
+    "gn:elevation":"296.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7729525,
+    "gn:latitude":42.2925,
+    "gn:longitude":-84.44694,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Walnut Ridge Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        1209639853,
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7729525
+    },
+    "wof:country":"US",
+    "wof:geomhash":"effcd8223a98822348f039dfad869f8a",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739849,
+            "country_id":85633793,
+            "locality_id":1209639853
+        }
+    ],
+    "wof:id":1393739849,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Walnut Ridge Manufactured Home Community",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209639853
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -84.44694,
+    42.2925,
+    -84.44694,
+    42.2925
+],
+  "geometry": {"coordinates":[-84.44694,42.2925],"type":"Point"}
+}

--- a/data/139/373/985/1/1393739851.geojson
+++ b/data/139/373/985/1/1393739851.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688719,
         102191575,
         85633793,
-        1276239361,
-        102081547
+        102081547,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102081547,
-            "locality_id":1276239361,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688719
         }
     ],
     "wof:id":1393739851,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168072,
     "wof:name":"Meridian Manufactured Home Park",
-    "wof:parent_id":102081547,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/985/1/1393739851.geojson
+++ b/data/139/373/985/1/1393739851.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739851,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-111.5792,33.41856,-111.5792,33.41856",
+    "geom:latitude":33.41856,
+    "geom:longitude":-111.5792,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"21.0",
+    "gn:asciiname":"Meridian Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":502,
+    "gn:elevation":"503.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8483806,
+    "gn:latitude":33.41856,
+    "gn:longitude":-111.5792,
+    "gn:modification_date":"2013-03-08",
+    "gn:name":"Meridian Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688719,
+        102191575,
+        85633793,
+        1276239361,
+        102081547
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8483806
+    },
+    "wof:country":"US",
+    "wof:geomhash":"224b5936381441c82014c359e53856ee",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739851,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081547,
+            "locality_id":1276239361,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1393739851,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Meridian Manufactured Home Park",
+    "wof:parent_id":102081547,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276239361
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -111.5792,
+    33.41856,
+    -111.5792,
+    33.41856
+],
+  "geometry": {"coordinates":[-111.5792,33.41856],"type":"Point"}
+}

--- a/data/139/373/985/3/1393739853.geojson
+++ b/data/139/373/985/3/1393739853.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1360304617,
-        102084753
+        102084753,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084753,
-            "locality_id":1360304617,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739853,
-    "wof:lastmodified":1559156962,
+    "wof:lastmodified":1559168073,
     "wof:name":"Magnolia Circle Manufactured Home Community",
-    "wof:parent_id":102084753,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/985/3/1393739853.geojson
+++ b/data/139/373/985/3/1393739853.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739853,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.78001,30.25016,-81.78001,30.25016",
+    "geom:latitude":30.25016,
+    "geom:longitude":-81.78001,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"31.0",
+    "gn:asciiname":"Magnolia Circle Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":29,
+    "gn:elevation":"24.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7189950,
+    "gn:latitude":30.25016,
+    "gn:longitude":-81.78001,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Magnolia Circle Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1360304617,
+        102084753
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7189950
+    },
+    "wof:country":"US",
+    "wof:geomhash":"153cf9c49e68d2ef9cb509289cc0b9ef",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739853,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084753,
+            "locality_id":1360304617,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739853,
+    "wof:lastmodified":1559156962,
+    "wof:name":"Magnolia Circle Manufactured Home Community",
+    "wof:parent_id":102084753,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1360304617
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.78001,
+    30.25016,
+    -81.78001,
+    30.25016
+],
+  "geometry": {"coordinates":[-81.78001,30.25016],"type":"Point"}
+}

--- a/data/139/373/985/5/1393739855.geojson
+++ b/data/139/373/985/5/1393739855.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739855,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.67324,29.57588,-81.67324,29.57588",
+    "geom:latitude":29.57588,
+    "geom:longitude":-81.67324,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"107.0",
+    "gn:asciiname":"River Villas Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":6,
+    "gn:elevation":"5.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7193040,
+    "gn:latitude":29.57588,
+    "gn:longitude":-81.67324,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"River Villas Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1309921727,
+        102085849
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7193040
+    },
+    "wof:country":"US",
+    "wof:geomhash":"20849f893b6a8fe439630d92c21b02e3",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739855,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085849,
+            "locality_id":1309921727,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739855,
+    "wof:lastmodified":1559156963,
+    "wof:name":"River Villas Manufactured Home Park",
+    "wof:parent_id":102085849,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309921727
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.67324,
+    29.57588,
+    -81.67324,
+    29.57588
+],
+  "geometry": {"coordinates":[-81.67324000000001,29.57588],"type":"Point"}
+}

--- a/data/139/373/985/5/1393739855.geojson
+++ b/data/139/373/985/5/1393739855.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1309921727,
-        102085849
+        102085849,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085849,
-            "locality_id":1309921727,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739855,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168073,
     "wof:name":"River Villas Manufactured Home Park",
-    "wof:parent_id":102085849,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/985/7/1393739857.geojson
+++ b/data/139/373/985/7/1393739857.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739857,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.99557,29.114,-80.99557,29.114",
+    "geom:latitude":29.114,
+    "geom:longitude":-80.99557,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"127.0",
+    "gn:asciiname":"Parkwood Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":4,
+    "gn:elevation":"3.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7192811,
+    "gn:latitude":29.114,
+    "gn:longitude":-80.99557,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Parkwood Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1276248053,
+        102085865
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7192811
+    },
+    "wof:country":"US",
+    "wof:geomhash":"4d5e531712c3a89600aa1dbc15f554de",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739857,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085865,
+            "locality_id":1276248053,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739857,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Parkwood Manufactured Home Community",
+    "wof:parent_id":102085865,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276248053
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.99557,
+    29.114,
+    -80.99557,
+    29.114
+],
+  "geometry": {"coordinates":[-80.99557,29.114],"type":"Point"}
+}

--- a/data/139/373/985/7/1393739857.geojson
+++ b/data/139/373/985/7/1393739857.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1276248053,
-        102085865
+        102085865,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085865,
-            "locality_id":1276248053,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739857,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168076,
     "wof:name":"Parkwood Manufactured Home Community",
-    "wof:parent_id":102085865,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/985/9/1393739859.geojson
+++ b/data/139/373/985/9/1393739859.geojson
@@ -30,8 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        1209631251,
-        85633793
+        102191575,
+        85633793,
+        102087803,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -42,14 +44,18 @@
     "wof:hierarchy":[
         {
             "campus_id":1393739859,
+            "continent_id":102191575,
             "country_id":85633793,
-            "locality_id":1209631251
+            "county_id":102087803,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":85688727
         }
     ],
     "wof:id":1393739859,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168076,
     "wof:name":"Heisler Manufactured Home Park",
-    "wof:parent_id":85633793,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/985/9/1393739859.geojson
+++ b/data/139/373/985/9/1393739859.geojson
@@ -1,0 +1,68 @@
+{
+  "id": 1393739859,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-95.82111,46.64444,-95.82111,46.64444",
+    "geom:latitude":46.64444,
+    "geom:longitude":-95.82111,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"111.0",
+    "gn:admin3_code":"9622.0",
+    "gn:asciiname":"Heisler Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":416,
+    "gn:elevation":"418.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":6332694,
+    "gn:latitude":46.64444,
+    "gn:longitude":-95.82111,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Heisler Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        1209631251,
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":6332694
+    },
+    "wof:country":"US",
+    "wof:geomhash":"dffa9434751fc29c651030373238b78f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739859,
+            "country_id":85633793,
+            "locality_id":1209631251
+        }
+    ],
+    "wof:id":1393739859,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Heisler Manufactured Home Park",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209631251
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -95.82111,
+    46.64444,
+    -95.82111,
+    46.64444
+],
+  "geometry": {"coordinates":[-95.82111,46.64444],"type":"Point"}
+}

--- a/data/139/373/986/1/1393739861.geojson
+++ b/data/139/373/986/1/1393739861.geojson
@@ -29,12 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688697,
         102191575,
-        404499233,
         85633793,
-        1293507031,
-        102084325
+        102084325,
+        85688697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -48,15 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084325,
-            "localadmin_id":404499233,
-            "locality_id":1293507031,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688697
         }
     ],
     "wof:id":1393739861,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168077,
     "wof:name":"Paradise Acres Manufactured Home Community",
-    "wof:parent_id":404499233,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/986/1/1393739861.geojson
+++ b/data/139/373/986/1/1393739861.geojson
@@ -1,0 +1,75 @@
+{
+  "id": 1393739861,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-89.11556,37.765,-89.11556,37.765",
+    "geom:latitude":37.765,
+    "geom:longitude":-89.11556,
+    "gn:admin1_code":"IL",
+    "gn:admin2_code":"199.0",
+    "gn:asciiname":"Paradise Acres Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":128,
+    "gn:elevation":"128.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7728119,
+    "gn:latitude":37.765,
+    "gn:longitude":-89.11556,
+    "gn:modification_date":"2011-03-13",
+    "gn:name":"Paradise Acres Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688697,
+        102191575,
+        404499233,
+        85633793,
+        1293507031,
+        102084325
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7728119
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f77cf4882c574645f3cd61cb21db5f0b",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739861,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084325,
+            "localadmin_id":404499233,
+            "locality_id":1293507031,
+            "region_id":85688697
+        }
+    ],
+    "wof:id":1393739861,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Paradise Acres Manufactured Home Community",
+    "wof:parent_id":404499233,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293507031
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -89.11556,
+    37.765,
+    -89.11556,
+    37.765
+],
+  "geometry": {"coordinates":[-89.11556,37.765],"type":"Point"}
+}

--- a/data/139/373/986/3/1393739863.geojson
+++ b/data/139/373/986/3/1393739863.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739863,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-121.99423,47.19388,-121.99423,47.19388",
+    "geom:latitude":47.19388,
+    "geom:longitude":-121.99423,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"33.0",
+    "gn:asciiname":"Mountain Meadows Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":222,
+    "gn:elevation":"223.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714079,
+    "gn:latitude":47.19388,
+    "gn:longitude":-121.99423,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Mountain Meadows Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688623,
+        102191575,
+        85633793,
+        1343577651,
+        102086191
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714079
+    },
+    "wof:country":"US",
+    "wof:geomhash":"4a4d522f4c3e7fbff90c77ce40350942",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739863,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086191,
+            "locality_id":1343577651,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1393739863,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Mountain Meadows Manufactured Home Community",
+    "wof:parent_id":102086191,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343577651
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -121.99423,
+    47.19388,
+    -121.99423,
+    47.19388
+],
+  "geometry": {"coordinates":[-121.99423,47.19388],"type":"Point"}
+}

--- a/data/139/373/986/3/1393739863.geojson
+++ b/data/139/373/986/3/1393739863.geojson
@@ -32,7 +32,7 @@
         85688623,
         102191575,
         85633793,
-        1343577651,
+        101730259,
         102086191
     ],
     "wof:breaches":[],
@@ -47,14 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102086191,
-            "locality_id":1343577651,
+            "locality_id":101730259,
+            "neighbourhood_id":-1,
             "region_id":85688623
         }
     ],
     "wof:id":1393739863,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168078,
     "wof:name":"Mountain Meadows Manufactured Home Community",
-    "wof:parent_id":102086191,
+    "wof:parent_id":101730259,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/986/7/1393739867.geojson
+++ b/data/139/373/986/7/1393739867.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739867,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-84.475,42.27806,-84.475,42.27806",
+    "geom:latitude":42.27806,
+    "geom:longitude":-84.475,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"75.0",
+    "gn:admin3_code":"8760.0",
+    "gn:asciiname":"Windham Hill Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":303,
+    "gn:elevation":"303.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7729522,
+    "gn:latitude":42.27806,
+    "gn:longitude":-84.475,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Windham Hill Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404507769,
+        85633793,
+        1326964519,
+        102083081
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7729522
+    },
+    "wof:country":"US",
+    "wof:geomhash":"bbda6ca08ff8d5b9cb01117c26a215f8",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739867,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083081,
+            "localadmin_id":404507769,
+            "locality_id":1326964519,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739867,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Windham Hill Manufactured Home Community",
+    "wof:parent_id":404507769,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326964519
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -84.475,
+    42.27806,
+    -84.475,
+    42.27806
+],
+  "geometry": {"coordinates":[-84.47499999999999,42.27806],"type":"Point"}
+}

--- a/data/139/373/986/7/1393739867.geojson
+++ b/data/139/373/986/7/1393739867.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507769,
         85633793,
-        1326964519,
-        102083081
+        102083081,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083081,
-            "localadmin_id":404507769,
-            "locality_id":1326964519,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739867,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168080,
     "wof:name":"Windham Hill Manufactured Home Community",
-    "wof:parent_id":404507769,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/986/9/1393739869.geojson
+++ b/data/139/373/986/9/1393739869.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522103,
         85633793,
-        1226362133,
-        102081819
+        102081819,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102081819,
-            "localadmin_id":404522103,
-            "locality_id":1226362133,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688543
         }
     ],
     "wof:id":1393739869,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168081,
     "wof:name":"North Star Manufactured Home Community",
-    "wof:parent_id":404522103,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/986/9/1393739869.geojson
+++ b/data/139/373/986/9/1393739869.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739869,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.78722,42.02528,-76.78722,42.02528",
+    "geom:latitude":42.02528,
+    "geom:longitude":-76.78722,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"15",
+    "gn:admin3_code":"2781.0",
+    "gn:asciiname":"North Star Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":438,
+    "gn:elevation":"433.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7235002,
+    "gn:latitude":42.02528,
+    "gn:longitude":-76.78722,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"North Star Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688543,
+        102191575,
+        404522103,
+        85633793,
+        1226362133,
+        102081819
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7235002
+    },
+    "wof:country":"US",
+    "wof:geomhash":"bddb18c737dba723bb0eb4f50a1c4071",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739869,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081819,
+            "localadmin_id":404522103,
+            "locality_id":1226362133,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1393739869,
+    "wof:lastmodified":1559156963,
+    "wof:name":"North Star Manufactured Home Community",
+    "wof:parent_id":404522103,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226362133
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.78721999999998,
+    42.02528,
+    -76.78721999999998,
+    42.02528
+],
+  "geometry": {"coordinates":[-76.78721999999998,42.02528],"type":"Point"}
+}

--- a/data/139/373/987/1/1393739871.geojson
+++ b/data/139/373/987/1/1393739871.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739871,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-84.77,43.56389,-84.77,43.56389",
+    "geom:latitude":43.56389,
+    "geom:longitude":-84.77,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"73",
+    "gn:admin3_code":"81340.0",
+    "gn:asciiname":"Pleasant Ridge Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":250,
+    "gn:elevation":"250.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7240786,
+    "gn:latitude":43.56389,
+    "gn:longitude":-84.77,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Pleasant Ridge Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404507765,
+        85633793,
+        1293426437,
+        102083065
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7240786
+    },
+    "wof:country":"US",
+    "wof:geomhash":"55eae2bb479435a2cb58db8662e661d8",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739871,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083065,
+            "localadmin_id":404507765,
+            "locality_id":1293426437,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739871,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Pleasant Ridge Manufactured Home Community",
+    "wof:parent_id":404507765,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293426437
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -84.77,
+    43.56389,
+    -84.77,
+    43.56389
+],
+  "geometry": {"coordinates":[-84.77,43.56389],"type":"Point"}
+}

--- a/data/139/373/987/1/1393739871.geojson
+++ b/data/139/373/987/1/1393739871.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507765,
         85633793,
-        1293426437,
-        102083065
+        102083065,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083065,
-            "localadmin_id":404507765,
-            "locality_id":1293426437,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739871,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168082,
     "wof:name":"Pleasant Ridge Manufactured Home Community",
-    "wof:parent_id":404507765,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/987/3/1393739873.geojson
+++ b/data/139/373/987/3/1393739873.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404502889,
         85633793,
-        1293309041,
-        102084179
+        102084179,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084179,
-            "localadmin_id":404502889,
-            "locality_id":1293309041,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688555
         }
     ],
     "wof:id":1393739873,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168082,
     "wof:name":"Redbud Estates Manufactured Home Community",
-    "wof:parent_id":404502889,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/987/3/1393739873.geojson
+++ b/data/139/373/987/3/1393739873.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739873,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-96.60163,39.17872,-96.60163,39.17872",
+    "geom:latitude":39.17872,
+    "geom:longitude":-96.60163,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"161.0",
+    "gn:admin3_code":"44250.0",
+    "gn:asciiname":"Redbud Estates Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":315,
+    "gn:elevation":"315.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8122804,
+    "gn:latitude":39.17872,
+    "gn:longitude":-96.60163,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Redbud Estates Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688555,
+        102191575,
+        404502889,
+        85633793,
+        1293309041,
+        102084179
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8122804
+    },
+    "wof:country":"US",
+    "wof:geomhash":"7895b9693a350017a5d7453a859d7004",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739873,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084179,
+            "localadmin_id":404502889,
+            "locality_id":1293309041,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1393739873,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Redbud Estates Manufactured Home Community",
+    "wof:parent_id":404502889,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293309041
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -96.60163,
+    39.17872,
+    -96.60163,
+    39.17872
+],
+  "geometry": {"coordinates":[-96.60163,39.17872],"type":"Point"}
+}

--- a/data/139/373/987/5/1393739875.geojson
+++ b/data/139/373/987/5/1393739875.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739875,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.6062,48.32703,-122.6062,48.32703",
+    "geom:latitude":48.32703,
+    "geom:longitude":-122.6062,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"29.0",
+    "gn:asciiname":"Island Park Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":57,
+    "gn:elevation":"57.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714266,
+    "gn:latitude":48.32703,
+    "gn:longitude":-122.6062,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Island Park Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688623,
+        102191575,
+        85633793,
+        1276355873,
+        102087543
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714266
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6579d9442dc32258b7dafd12a93545f3",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739875,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087543,
+            "locality_id":1276355873,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1393739875,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Island Park Manufactured Home Park",
+    "wof:parent_id":102087543,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276355873
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.6062,
+    48.32703,
+    -122.6062,
+    48.32703
+],
+  "geometry": {"coordinates":[-122.6062,48.32703],"type":"Point"}
+}

--- a/data/139/373/987/5/1393739875.geojson
+++ b/data/139/373/987/5/1393739875.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688623,
         102191575,
         85633793,
-        1276355873,
-        102087543
+        102087543,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102087543,
-            "locality_id":1276355873,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688623
         }
     ],
     "wof:id":1393739875,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168085,
     "wof:name":"Island Park Manufactured Home Park",
-    "wof:parent_id":102087543,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/987/7/1393739877.geojson
+++ b/data/139/373/987/7/1393739877.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688747,
         102191575,
         85633793,
-        1210035731,
-        102086709
+        102086709,
+        85688747
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102086709,
-            "locality_id":1210035731,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688747
         }
     ],
     "wof:id":1393739877,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168085,
     "wof:name":"Lakeside Manufactured Home Community",
-    "wof:parent_id":102086709,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/987/7/1393739877.geojson
+++ b/data/139/373/987/7/1393739877.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739877,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.69074,36.92352,-76.69074,36.92352",
+    "geom:latitude":36.92352,
+    "geom:longitude":-76.69074,
+    "gn:admin1_code":"VA",
+    "gn:admin2_code":"93",
+    "gn:asciiname":"Lakeside Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":26,
+    "gn:elevation":"24.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7238554,
+    "gn:latitude":36.92352,
+    "gn:longitude":-76.69074,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Lakeside Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688747,
+        102191575,
+        85633793,
+        1210035731,
+        102086709
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7238554
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6ddea657ae7be4c65057a19f94bcf315",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739877,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086709,
+            "locality_id":1210035731,
+            "region_id":85688747
+        }
+    ],
+    "wof:id":1393739877,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Lakeside Manufactured Home Community",
+    "wof:parent_id":102086709,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1210035731
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.69074,
+    36.92352,
+    -76.69074,
+    36.92352
+],
+  "geometry": {"coordinates":[-76.69074000000001,36.92352],"type":"Point"}
+}

--- a/data/139/373/987/9/1393739879.geojson
+++ b/data/139/373/987/9/1393739879.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1344181531,
-        102084721
+        102084721,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084721,
-            "locality_id":1344181531,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739879,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168086,
     "wof:name":"Riverview Manufactured Home Community",
-    "wof:parent_id":102084721,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/987/9/1393739879.geojson
+++ b/data/139/373/987/9/1393739879.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739879,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.66183,28.19798,-80.66183,28.19798",
+    "geom:latitude":28.19798,
+    "geom:longitude":-80.66183,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"9.0",
+    "gn:asciiname":"Riverview Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":13,
+    "gn:elevation":"7.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7191816,
+    "gn:latitude":28.19798,
+    "gn:longitude":-80.66183,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Riverview Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1344181531,
+        102084721
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7191816
+    },
+    "wof:country":"US",
+    "wof:geomhash":"bec498d31fc6ef7bd74100f46539edf1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739879,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084721,
+            "locality_id":1344181531,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739879,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Riverview Manufactured Home Community",
+    "wof:parent_id":102084721,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1344181531
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.66183000000002,
+    28.19798,
+    -80.66183000000002,
+    28.19798
+],
+  "geometry": {"coordinates":[-80.66183000000002,28.19798],"type":"Point"}
+}

--- a/data/139/373/988/1/1393739881.geojson
+++ b/data/139/373/988/1/1393739881.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739881,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-90.90362,30.26068,-90.90362,30.26068",
+    "geom:latitude":30.26068,
+    "geom:longitude":-90.90362,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"5.0",
+    "gn:asciiname":"Cobb's Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":5,
+    "gn:elevation":"3.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7708234,
+    "gn:latitude":30.26068,
+    "gn:longitude":-90.90362,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Cobb's Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688735,
+        102191575,
+        85633793,
+        1343973841,
+        102086687
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7708234
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f65c3be21726a7963dba483894ad12fe",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739881,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086687,
+            "locality_id":1343973841,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1393739881,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Cobb's Manufactured Home Park",
+    "wof:parent_id":102086687,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343973841
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -90.90362,
+    30.26068,
+    -90.90362,
+    30.26068
+],
+  "geometry": {"coordinates":[-90.90362,30.26068],"type":"Point"}
+}

--- a/data/139/373/988/1/1393739881.geojson
+++ b/data/139/373/988/1/1393739881.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688735,
         102191575,
         85633793,
-        1343973841,
-        102086687
+        102086687,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102086687,
-            "locality_id":1343973841,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688735
         }
     ],
     "wof:id":1393739881,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168087,
     "wof:name":"Cobb's Manufactured Home Park",
-    "wof:parent_id":102086687,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/988/5/1393739885.geojson
+++ b/data/139/373/988/5/1393739885.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739885,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-83.69389,41.73778,-83.69389,41.73778",
+    "geom:latitude":41.73778,
+    "geom:longitude":-83.69389,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"115.0",
+    "gn:admin3_code":"86740.0",
+    "gn:asciiname":"Hidden Creek Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":202,
+    "gn:elevation":"204.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7188384,
+    "gn:latitude":41.73778,
+    "gn:longitude":-83.69389,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Hidden Creek Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404506281,
+        85633793,
+        1276909765,
+        102083117
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7188384
+    },
+    "wof:country":"US",
+    "wof:geomhash":"12faa2e7a43b0a44bb965ba8e28e9d4c",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739885,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083117,
+            "localadmin_id":404506281,
+            "locality_id":1276909765,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739885,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Hidden Creek Manufactured Home Community",
+    "wof:parent_id":404506281,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276909765
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -83.69389,
+    41.73778,
+    -83.69389,
+    41.73778
+],
+  "geometry": {"coordinates":[-83.69389,41.73778],"type":"Point"}
+}

--- a/data/139/373/988/5/1393739885.geojson
+++ b/data/139/373/988/5/1393739885.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506281,
         85633793,
-        1276909765,
-        102083117
+        102083117,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083117,
-            "localadmin_id":404506281,
-            "locality_id":1276909765,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739885,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168090,
     "wof:name":"Hidden Creek Manufactured Home Community",
-    "wof:parent_id":404506281,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/988/7/1393739887.geojson
+++ b/data/139/373/988/7/1393739887.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688637,
         102191575,
         85633793,
-        1327046325,
-        102082309
+        102082309,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102082309,
-            "locality_id":1327046325,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688637
         }
     ],
     "wof:id":1393739887,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168090,
     "wof:name":"Royal Oak Manufactured Home Community",
-    "wof:parent_id":102082309,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/988/7/1393739887.geojson
+++ b/data/139/373/988/7/1393739887.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739887,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-121.73,38.54472,-121.73,38.54472",
+    "geom:latitude":38.54472,
+    "geom:longitude":-121.73,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"113",
+    "gn:asciiname":"Royal Oak Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":13,
+    "gn:elevation":"14.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7231892,
+    "gn:latitude":38.54472,
+    "gn:longitude":-121.73,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Royal Oak Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688637,
+        102191575,
+        85633793,
+        1327046325,
+        102082309
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7231892
+    },
+    "wof:country":"US",
+    "wof:geomhash":"88912da5a4b0dc6134bf7ada9c07381d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739887,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082309,
+            "locality_id":1327046325,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1393739887,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Royal Oak Manufactured Home Community",
+    "wof:parent_id":102082309,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1327046325
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -121.73,
+    38.54472,
+    -121.73,
+    38.54472
+],
+  "geometry": {"coordinates":[-121.73,38.54472],"type":"Point"}
+}

--- a/data/139/373/988/9/1393739889.geojson
+++ b/data/139/373/988/9/1393739889.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739889,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.49943,27.87048,-80.49943,27.87048",
+    "geom:latitude":27.87048,
+    "geom:longitude":-80.49943,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"9.0",
+    "gn:asciiname":"Pelican Bay Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":8,
+    "gn:elevation":"7.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7191131,
+    "gn:latitude":27.87048,
+    "gn:longitude":-80.49943,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Pelican Bay Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1226453681,
+        102084721
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7191131
+    },
+    "wof:country":"US",
+    "wof:geomhash":"676295edf9b1130be944903ebecf0eef",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739889,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084721,
+            "locality_id":1226453681,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739889,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Pelican Bay Manufactured Home Community",
+    "wof:parent_id":102084721,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226453681
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.49943,
+    27.87048,
+    -80.49943,
+    27.87048
+],
+  "geometry": {"coordinates":[-80.49943,27.87048],"type":"Point"}
+}

--- a/data/139/373/988/9/1393739889.geojson
+++ b/data/139/373/988/9/1393739889.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1226453681,
-        102084721
+        102084721,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084721,
-            "locality_id":1226453681,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739889,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168091,
     "wof:name":"Pelican Bay Manufactured Home Community",
-    "wof:parent_id":102084721,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/989/1/1393739891.geojson
+++ b/data/139/373/989/1/1393739891.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688675,
         102191575,
         85633793,
-        1226069113,
-        102085585
+        102085585,
+        85688675
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085585,
-            "locality_id":1226069113,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688675
         }
     ],
     "wof:id":1393739891,
-    "wof:lastmodified":1559156963,
+    "wof:lastmodified":1559168092,
     "wof:name":"Magnolia Pointe Manufactured Home Community",
-    "wof:parent_id":102085585,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/989/1/1393739891.geojson
+++ b/data/139/373/989/1/1393739891.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739891,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-88.22764,30.66312,-88.22764,30.66312",
+    "geom:latitude":30.66312,
+    "geom:longitude":-88.22764,
+    "gn:admin1_code":"AL",
+    "gn:admin2_code":"97.0",
+    "gn:asciiname":"Magnolia Pointe Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":55,
+    "gn:elevation":"52.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7312950,
+    "gn:latitude":30.66312,
+    "gn:longitude":-88.22764,
+    "gn:modification_date":"2011-01-10",
+    "gn:name":"Magnolia Pointe Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688675,
+        102191575,
+        85633793,
+        1226069113,
+        102085585
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7312950
+    },
+    "wof:country":"US",
+    "wof:geomhash":"519642169a1a94f55f3d827a15cc2e50",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739891,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085585,
+            "locality_id":1226069113,
+            "region_id":85688675
+        }
+    ],
+    "wof:id":1393739891,
+    "wof:lastmodified":1559156963,
+    "wof:name":"Magnolia Pointe Manufactured Home Community",
+    "wof:parent_id":102085585,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226069113
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -88.22764000000002,
+    30.66312000000001,
+    -88.22764000000002,
+    30.66312000000001
+],
+  "geometry": {"coordinates":[-88.22764000000002,30.66312000000001],"type":"Point"}
+}

--- a/data/139/373/989/3/1393739893.geojson
+++ b/data/139/373/989/3/1393739893.geojson
@@ -1,0 +1,74 @@
+{
+  "id": 1393739893,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-91.68907,42.03333,-91.68907,42.03333",
+    "geom:latitude":42.03333,
+    "geom:longitude":-91.68907,
+    "gn:admin1_code":"IA",
+    "gn:admin2_code":"113.0",
+    "gn:admin3_code":"90577.0",
+    "gn:asciiname":"Five Seasons Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":256,
+    "gn:elevation":"255.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4857233,
+    "gn:latitude":42.03333,
+    "gn:longitude":-91.68907,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Five Seasons Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688713,
+        102191575,
+        85633793,
+        1360195615,
+        102086551
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4857233
+    },
+    "wof:country":"US",
+    "wof:geomhash":"4223da8f60aa092c18e3e4298adc264c",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739893,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086551,
+            "locality_id":1360195615,
+            "region_id":85688713
+        }
+    ],
+    "wof:id":1393739893,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Five Seasons Manufactured Home Community",
+    "wof:parent_id":102086551,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1360195615
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -91.68907,
+    42.03333,
+    -91.68907,
+    42.03333
+],
+  "geometry": {"coordinates":[-91.68907,42.03333],"type":"Point"}
+}

--- a/data/139/373/989/3/1393739893.geojson
+++ b/data/139/373/989/3/1393739893.geojson
@@ -30,11 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688713,
         102191575,
         85633793,
-        1360195615,
-        102086551
+        102086551,
+        85688713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -48,14 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102086551,
-            "locality_id":1360195615,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688713
         }
     ],
     "wof:id":1393739893,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168094,
     "wof:name":"Five Seasons Manufactured Home Community",
-    "wof:parent_id":102086551,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/989/5/1393739895.geojson
+++ b/data/139/373/989/5/1393739895.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507379,
         85633793,
-        1326654433,
-        102083099
+        102083099,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083099,
-            "localadmin_id":404507379,
-            "locality_id":1326654433,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739895,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168095,
     "wof:name":"Maple Woods Manufactured Home Community",
-    "wof:parent_id":404507379,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/989/5/1393739895.geojson
+++ b/data/139/373/989/5/1393739895.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739895,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-84.06806,41.88889,-84.06806,41.88889",
+    "geom:latitude":41.88889,
+    "geom:longitude":-84.06806,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"91.0",
+    "gn:admin3_code":"50540.0",
+    "gn:asciiname":"Maple Woods Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":247,
+    "gn:elevation":"246.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7187162,
+    "gn:latitude":41.88889,
+    "gn:longitude":-84.06806,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Maple Woods Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404507379,
+        85633793,
+        1326654433,
+        102083099
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7187162
+    },
+    "wof:country":"US",
+    "wof:geomhash":"5ea7165278cfa82b94d3d5ceb890c237",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739895,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083099,
+            "localadmin_id":404507379,
+            "locality_id":1326654433,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739895,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Maple Woods Manufactured Home Community",
+    "wof:parent_id":404507379,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326654433
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -84.06806,
+    41.88889,
+    -84.06806,
+    41.88889
+],
+  "geometry": {"coordinates":[-84.06806,41.88889],"type":"Point"}
+}

--- a/data/139/373/989/7/1393739897.geojson
+++ b/data/139/373/989/7/1393739897.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404504929,
         85633793,
-        1293415961,
-        102084203
+        102084203,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084203,
-            "localadmin_id":404504929,
-            "locality_id":1293415961,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688555
         }
     ],
     "wof:id":1393739897,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168096,
     "wof:name":"Lakeside Manufactured Home Community",
-    "wof:parent_id":404504929,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/989/7/1393739897.geojson
+++ b/data/139/373/989/7/1393739897.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739897,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-97.39154,37.6457,-97.39154,37.6457",
+    "geom:latitude":37.6457,
+    "geom:longitude":-97.39154,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"173",
+    "gn:admin3_code":"79000.0",
+    "gn:asciiname":"Lakeside Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":397,
+    "gn:elevation":"394.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7233370,
+    "gn:latitude":37.6457,
+    "gn:longitude":-97.39154,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Lakeside Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688555,
+        102191575,
+        404504929,
+        85633793,
+        1293415961,
+        102084203
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7233370
+    },
+    "wof:country":"US",
+    "wof:geomhash":"9ae933b18dc6c9ce91f160679654dd73",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739897,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084203,
+            "localadmin_id":404504929,
+            "locality_id":1293415961,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1393739897,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Lakeside Manufactured Home Community",
+    "wof:parent_id":404504929,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293415961
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -97.39154,
+    37.6457,
+    -97.39154,
+    37.6457
+],
+  "geometry": {"coordinates":[-97.39154000000001,37.6457],"type":"Point"}
+}

--- a/data/139/373/989/9/1393739899.geojson
+++ b/data/139/373/989/9/1393739899.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739899,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-92.01016,43.55524,-92.01016,43.55524",
+    "geom:latitude":43.55524,
+    "geom:longitude":-92.01016,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"45.0",
+    "gn:admin3_code":"27188.0",
+    "gn:asciiname":"Vikre Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":414,
+    "gn:elevation":"412.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5051423,
+    "gn:latitude":43.55524,
+    "gn:longitude":-92.01016,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Vikre Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688727,
+        102191575,
+        404514259,
+        85633793,
+        1226458677,
+        102086997
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5051423
+    },
+    "wof:country":"US",
+    "wof:geomhash":"c4b513ef1f0b858e449481e7122d5c97",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739899,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086997,
+            "localadmin_id":404514259,
+            "locality_id":1226458677,
+            "region_id":85688727
+        }
+    ],
+    "wof:id":1393739899,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Vikre Manufactured Home Park",
+    "wof:parent_id":404514259,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226458677
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -92.01016,
+    43.55524000000001,
+    -92.01016,
+    43.55524000000001
+],
+  "geometry": {"coordinates":[-92.01016,43.55524000000001],"type":"Point"}
+}

--- a/data/139/373/989/9/1393739899.geojson
+++ b/data/139/373/989/9/1393739899.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404514259,
         85633793,
-        1226458677,
-        102086997
+        102086997,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102086997,
-            "localadmin_id":404514259,
-            "locality_id":1226458677,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688727
         }
     ],
     "wof:id":1393739899,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168096,
     "wof:name":"Vikre Manufactured Home Park",
-    "wof:parent_id":404514259,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/990/3/1393739903.geojson
+++ b/data/139/373/990/3/1393739903.geojson
@@ -32,10 +32,9 @@
     "wof:belongsto":[
         85688543,
         102191575,
-        404522863,
         85633793,
-        1309931365,
-        102082359
+        102082359,
+        420558533
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +48,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102082359,
-            "localadmin_id":404522863,
-            "locality_id":1309931365,
+            "locality_id":-1,
+            "neighbourhood_id":420558533,
             "region_id":85688543
         }
     ],
     "wof:id":1393739903,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168099,
     "wof:name":"Farmington Manufactured Home Community",
-    "wof:parent_id":404522863,
+    "wof:parent_id":420558533,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/990/3/1393739903.geojson
+++ b/data/139/373/990/3/1393739903.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739903,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-77.36268,42.97777,-77.36268,42.97777",
+    "geom:latitude":42.97777,
+    "geom:longitude":-77.36268,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"69.0",
+    "gn:admin3_code":"25406.0",
+    "gn:asciiname":"Farmington Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":192,
+    "gn:elevation":"189.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":9670231,
+    "gn:latitude":42.97777,
+    "gn:longitude":-77.36268,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Farmington Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688543,
+        102191575,
+        404522863,
+        85633793,
+        1309931365,
+        102082359
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":9670231
+    },
+    "wof:country":"US",
+    "wof:geomhash":"db99177f0f4a722114d7b624878905f1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739903,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082359,
+            "localadmin_id":404522863,
+            "locality_id":1309931365,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1393739903,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Farmington Manufactured Home Community",
+    "wof:parent_id":404522863,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309931365
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -77.36268000000003,
+    42.97777,
+    -77.36268000000003,
+    42.97777
+],
+  "geometry": {"coordinates":[-77.36268000000003,42.97777],"type":"Point"}
+}

--- a/data/139/373/990/5/1393739905.geojson
+++ b/data/139/373/990/5/1393739905.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739905,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.67444,42.23611,-85.67444,42.23611",
+    "geom:latitude":42.23611,
+    "geom:longitude":-85.67444,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"77.0",
+    "gn:admin3_code":"79300.0",
+    "gn:asciiname":"Wyngate Farms Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":288,
+    "gn:elevation":"289.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7727625,
+    "gn:latitude":42.23611,
+    "gn:longitude":-85.67444,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Wyngate Farms Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404506085,
+        85633793,
+        1276454301,
+        102083671
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7727625
+    },
+    "wof:country":"US",
+    "wof:geomhash":"15ac6026384047559f66d060e62defca",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739905,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083671,
+            "localadmin_id":404506085,
+            "locality_id":1276454301,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739905,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Wyngate Farms Manufactured Home Community",
+    "wof:parent_id":404506085,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276454301
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.67444,
+    42.23611,
+    -85.67444,
+    42.23611
+],
+  "geometry": {"coordinates":[-85.67444,42.23611],"type":"Point"}
+}

--- a/data/139/373/990/5/1393739905.geojson
+++ b/data/139/373/990/5/1393739905.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506085,
         85633793,
-        1276454301,
-        102083671
+        102083671,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083671,
-            "localadmin_id":404506085,
-            "locality_id":1276454301,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739905,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168100,
     "wof:name":"Wyngate Farms Manufactured Home Community",
-    "wof:parent_id":404506085,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/990/7/1393739907.geojson
+++ b/data/139/373/990/7/1393739907.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506085,
         85633793,
-        1277001571,
-        102083671
+        102083671,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083671,
-            "localadmin_id":404506085,
-            "locality_id":1277001571,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739907,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168100,
     "wof:name":"Saddlebrook Farms Manufactured Home Community",
-    "wof:parent_id":404506085,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/990/7/1393739907.geojson
+++ b/data/139/373/990/7/1393739907.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739907,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.725,42.24389,-85.725,42.24389",
+    "geom:latitude":42.24389,
+    "geom:longitude":-85.725,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"77.0",
+    "gn:admin3_code":"79300.0",
+    "gn:asciiname":"Saddlebrook Farms Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":289,
+    "gn:elevation":"290.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7727626,
+    "gn:latitude":42.24389,
+    "gn:longitude":-85.725,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Saddlebrook Farms Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404506085,
+        85633793,
+        1277001571,
+        102083671
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7727626
+    },
+    "wof:country":"US",
+    "wof:geomhash":"7a8531745e8d6121ff3a5389a6e99c74",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739907,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083671,
+            "localadmin_id":404506085,
+            "locality_id":1277001571,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739907,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Saddlebrook Farms Manufactured Home Community",
+    "wof:parent_id":404506085,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1277001571
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.725,
+    42.24389,
+    -85.725,
+    42.24389
+],
+  "geometry": {"coordinates":[-85.72499999999999,42.24389],"type":"Point"}
+}

--- a/data/139/373/990/9/1393739909.geojson
+++ b/data/139/373/990/9/1393739909.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522657,
         85633793,
-        1310130303,
-        102081815
+        102081815,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102081815,
-            "localadmin_id":404522657,
-            "locality_id":1310130303,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688543
         }
     ],
     "wof:id":1393739909,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168101,
     "wof:name":"Sunset Valley Manufactured Home Community",
-    "wof:parent_id":404522657,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/990/9/1393739909.geojson
+++ b/data/139/373/990/9/1393739909.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739909,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-77.46778,43.20861,-77.46778,43.20861",
+    "geom:latitude":43.20861,
+    "geom:longitude":-77.46778,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"55",
+    "gn:admin3_code":"78971.0",
+    "gn:asciiname":"Sunset Valley Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":128,
+    "gn:elevation":"127.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7220711,
+    "gn:latitude":43.20861,
+    "gn:longitude":-77.46778,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Sunset Valley Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688543,
+        102191575,
+        404522657,
+        85633793,
+        1310130303,
+        102081815
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7220711
+    },
+    "wof:country":"US",
+    "wof:geomhash":"75803fc2f843a7df1c5edb8df683c5ab",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739909,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081815,
+            "localadmin_id":404522657,
+            "locality_id":1310130303,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1393739909,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Sunset Valley Manufactured Home Community",
+    "wof:parent_id":404522657,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310130303
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -77.46778,
+    43.20861,
+    -77.46778,
+    43.20861
+],
+  "geometry": {"coordinates":[-77.46778,43.20861],"type":"Point"}
+}

--- a/data/139/373/991/1/1393739911.geojson
+++ b/data/139/373/991/1/1393739911.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739911,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.72439,30.23628,-81.72439,30.23628",
+    "geom:latitude":30.23628,
+    "geom:longitude":-81.72439,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"31.0",
+    "gn:asciiname":"Ortega Village Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":7,
+    "gn:elevation":"5.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7189956,
+    "gn:latitude":30.23628,
+    "gn:longitude":-81.72439,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Ortega Village Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1310224223,
+        102084753
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7189956
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f68dcd3c37d30588a96cca128a50e328",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739911,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084753,
+            "locality_id":1310224223,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739911,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Ortega Village Manufactured Home Community",
+    "wof:parent_id":102084753,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310224223
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.72439,
+    30.23628,
+    -81.72439,
+    30.23628
+],
+  "geometry": {"coordinates":[-81.72439,30.23628],"type":"Point"}
+}

--- a/data/139/373/991/1/1393739911.geojson
+++ b/data/139/373/991/1/1393739911.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1310224223,
-        102084753
+        102084753,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102084753,
-            "locality_id":1310224223,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739911,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168103,
     "wof:name":"Ortega Village Manufactured Home Community",
-    "wof:parent_id":102084753,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/991/3/1393739913.geojson
+++ b/data/139/373/991/3/1393739913.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739913,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.08343,47.30218,-122.08343,47.30218",
+    "geom:latitude":47.30218,
+    "geom:longitude":-122.08343,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"33.0",
+    "gn:asciiname":"Park Place Estates Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":130,
+    "gn:elevation":"127.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713976,
+    "gn:latitude":47.30218,
+    "gn:longitude":-122.08343,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Park Place Estates Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688623,
+        102191575,
+        85633793,
+        1293405735,
+        102086191
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713976
+    },
+    "wof:country":"US",
+    "wof:geomhash":"dcefb751215e32448cfc9ba4a295a9bb",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739913,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086191,
+            "locality_id":1293405735,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1393739913,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Park Place Estates Manufactured Home Park",
+    "wof:parent_id":102086191,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293405735
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.08343,
+    47.30218,
+    -122.08343,
+    47.30218
+],
+  "geometry": {"coordinates":[-122.08343000000001,47.30218],"type":"Point"}
+}

--- a/data/139/373/991/3/1393739913.geojson
+++ b/data/139/373/991/3/1393739913.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688623,
         102191575,
         85633793,
-        1293405735,
-        102086191
+        102086191,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102086191,
-            "locality_id":1293405735,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688623
         }
     ],
     "wof:id":1393739913,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168104,
     "wof:name":"Park Place Estates Manufactured Home Park",
-    "wof:parent_id":102086191,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/991/5/1393739915.geojson
+++ b/data/139/373/991/5/1393739915.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404515121,
         85633793,
-        1242803723,
-        102087861
+        102087861,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102087861,
-            "localadmin_id":404515121,
-            "locality_id":1242803723,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688727
         }
     ],
     "wof:id":1393739915,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168105,
     "wof:name":"Woodhaven Manufactured Home Community",
-    "wof:parent_id":404515121,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/991/5/1393739915.geojson
+++ b/data/139/373/991/5/1393739915.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739915,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-93.37083,45.39361,-93.37083,45.39361",
+    "geom:latitude":45.39361,
+    "geom:longitude":-93.37083,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"3.0",
+    "gn:admin3_code":"56950.0",
+    "gn:asciiname":"Woodhaven Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":276,
+    "gn:elevation":"281.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":6332156,
+    "gn:latitude":45.39361,
+    "gn:longitude":-93.37083,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Woodhaven Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688727,
+        102191575,
+        404515121,
+        85633793,
+        1242803723,
+        102087861
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":6332156
+    },
+    "wof:country":"US",
+    "wof:geomhash":"75b79ed539cb8411d88d1707eab6c831",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739915,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087861,
+            "localadmin_id":404515121,
+            "locality_id":1242803723,
+            "region_id":85688727
+        }
+    ],
+    "wof:id":1393739915,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Woodhaven Manufactured Home Community",
+    "wof:parent_id":404515121,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242803723
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -93.37083,
+    45.39361,
+    -93.37083,
+    45.39361
+],
+  "geometry": {"coordinates":[-93.37083,45.39361],"type":"Point"}
+}

--- a/data/139/373/991/7/1393739917.geojson
+++ b/data/139/373/991/7/1393739917.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1226267117,
-        102085779
+        102085779,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085779,
-            "locality_id":1226267117,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739917,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168106,
     "wof:name":"Golden Pond Village Manufactured Home Community",
-    "wof:parent_id":102085779,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/991/7/1393739917.geojson
+++ b/data/139/373/991/7/1393739917.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739917,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.098,29.0647,-82.098,29.0647",
+    "geom:latitude":29.0647,
+    "geom:longitude":-82.098,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"83.0",
+    "gn:asciiname":"Golden Pond Village Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":28,
+    "gn:elevation":"22.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7192037,
+    "gn:latitude":29.0647,
+    "gn:longitude":-82.098,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Golden Pond Village Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1226267117,
+        102085779
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7192037
+    },
+    "wof:country":"US",
+    "wof:geomhash":"bf59e915519e1ca2299dabc5df6cc048",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739917,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085779,
+            "locality_id":1226267117,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739917,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Golden Pond Village Manufactured Home Community",
+    "wof:parent_id":102085779,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226267117
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.098,
+    29.0647,
+    -82.098,
+    29.0647
+],
+  "geometry": {"coordinates":[-82.098,29.0647],"type":"Point"}
+}

--- a/data/139/373/992/1/1393739921.geojson
+++ b/data/139/373/992/1/1393739921.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739921,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-83.745,42.83417,-83.745,42.83417",
+    "geom:latitude":42.83417,
+    "geom:longitude":-83.745,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"49.0",
+    "gn:admin3_code":"27780.0",
+    "gn:asciiname":"Loon Lake Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":268,
+    "gn:elevation":"268.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7717993,
+    "gn:latitude":42.83417,
+    "gn:longitude":-83.745,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Loon Lake Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404506597,
+        85633793,
+        1226551215,
+        102083111
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7717993
+    },
+    "wof:country":"US",
+    "wof:geomhash":"98679d52b9c306b5a375bfde524df5ab",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739921,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083111,
+            "localadmin_id":404506597,
+            "locality_id":1226551215,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739921,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Loon Lake Manufactured Home Community",
+    "wof:parent_id":404506597,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226551215
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -83.745,
+    42.83417,
+    -83.745,
+    42.83417
+],
+  "geometry": {"coordinates":[-83.745,42.83417],"type":"Point"}
+}

--- a/data/139/373/992/1/1393739921.geojson
+++ b/data/139/373/992/1/1393739921.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506597,
         85633793,
-        1226551215,
-        102083111
+        102083111,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083111,
-            "localadmin_id":404506597,
-            "locality_id":1226551215,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739921,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168108,
     "wof:name":"Loon Lake Manufactured Home Community",
-    "wof:parent_id":404506597,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/992/3/1393739923.geojson
+++ b/data/139/373/992/3/1393739923.geojson
@@ -1,0 +1,73 @@
+{
+  "id": 1393739923,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.43493,25.5012,-80.43493,25.5012",
+    "geom:latitude":25.5012,
+    "geom:longitude":-80.43493,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"86.0",
+    "gn:asciiname":"Palm Garden Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":9,
+    "gn:elevation":"3.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7190775,
+    "gn:latitude":25.5012,
+    "gn:longitude":-80.43493,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Palm Garden Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688651,
+        102191575,
+        85633793,
+        1243465685,
+        102085771
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7190775
+    },
+    "wof:country":"US",
+    "wof:geomhash":"fb344ed647f2c9f806f7fd16b80a6688",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739923,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085771,
+            "locality_id":1243465685,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1393739923,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Palm Garden Manufactured Home Community",
+    "wof:parent_id":102085771,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243465685
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.43493000000002,
+    25.5012,
+    -80.43493000000002,
+    25.5012
+],
+  "geometry": {"coordinates":[-80.43493000000002,25.5012],"type":"Point"}
+}

--- a/data/139/373/992/3/1393739923.geojson
+++ b/data/139/373/992/3/1393739923.geojson
@@ -29,11 +29,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688651,
         102191575,
         85633793,
-        1243465685,
-        102085771
+        102085771,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,14 +46,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102085771,
-            "locality_id":1243465685,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688651
         }
     ],
     "wof:id":1393739923,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168109,
     "wof:name":"Palm Garden Manufactured Home Community",
-    "wof:parent_id":102085771,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/992/5/1393739925.geojson
+++ b/data/139/373/992/5/1393739925.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739925,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-86.22639,41.81083,-86.22639,41.81083",
+    "geom:latitude":41.81083,
+    "geom:longitude":-86.22639,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"21",
+    "gn:admin3_code":"57780.0",
+    "gn:asciiname":"Silverbrook Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":228,
+    "gn:elevation":"227.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7168438,
+    "gn:latitude":41.81083,
+    "gn:longitude":-86.22639,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Silverbrook Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688599,
+        102191575,
+        404507005,
+        85633793,
+        1259503143,
+        102083151
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7168438
+    },
+    "wof:country":"US",
+    "wof:geomhash":"42369fa1f0e73842f481c638ae7cefd1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739925,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083151,
+            "localadmin_id":404507005,
+            "locality_id":1259503143,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1393739925,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Silverbrook Manufactured Home Community",
+    "wof:parent_id":404507005,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259503143
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -86.22639000000002,
+    41.81083,
+    -86.22639000000002,
+    41.81083
+],
+  "geometry": {"coordinates":[-86.22639000000002,41.81083],"type":"Point"}
+}

--- a/data/139/373/992/5/1393739925.geojson
+++ b/data/139/373/992/5/1393739925.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507005,
         85633793,
-        1259503143,
-        102083151
+        102083151,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083151,
-            "localadmin_id":404507005,
-            "locality_id":1259503143,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688599
         }
     ],
     "wof:id":1393739925,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168110,
     "wof:name":"Silverbrook Manufactured Home Community",
-    "wof:parent_id":404507005,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/992/7/1393739927.geojson
+++ b/data/139/373/992/7/1393739927.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522861,
         85633793,
-        1326949873,
-        102082359
+        102082359,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102082359,
-            "localadmin_id":404522861,
-            "locality_id":1326949873,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688543
         }
     ],
     "wof:id":1393739927,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168111,
     "wof:name":"Lakeview Manufactured Home Community",
-    "wof:parent_id":404522861,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/992/7/1393739927.geojson
+++ b/data/139/373/992/7/1393739927.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739927,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-77.25035,42.85788,-77.25035,42.85788",
+    "geom:latitude":42.85788,
+    "geom:longitude":-77.25035,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"69.0",
+    "gn:admin3_code":"12155.0",
+    "gn:asciiname":"Lakeview Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":216,
+    "gn:elevation":"213.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8085322,
+    "gn:latitude":42.85788,
+    "gn:longitude":-77.25035,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Lakeview Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688543,
+        102191575,
+        404522861,
+        85633793,
+        1326949873,
+        102082359
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8085322
+    },
+    "wof:country":"US",
+    "wof:geomhash":"fb46240805efdc9c502a60a83ea79fea",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739927,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082359,
+            "localadmin_id":404522861,
+            "locality_id":1326949873,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1393739927,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Lakeview Manufactured Home Community",
+    "wof:parent_id":404522861,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326949873
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -77.25035,
+    42.85788,
+    -77.25035,
+    42.85788
+],
+  "geometry": {"coordinates":[-77.25035,42.85788],"type":"Point"}
+}

--- a/data/139/373/992/9/1393739929.geojson
+++ b/data/139/373/992/9/1393739929.geojson
@@ -1,0 +1,68 @@
+{
+  "id": 1393739929,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-77.2708,42.88337,-77.2708,42.88337",
+    "geom:latitude":42.88337,
+    "geom:longitude":-77.2708,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"69.0",
+    "gn:admin3_code":"12144.0",
+    "gn:asciiname":"Canandaigua Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":211,
+    "gn:elevation":"211.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8085290,
+    "gn:latitude":42.88337,
+    "gn:longitude":-77.2708,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Canandaigua Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        1209029399,
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8085290
+    },
+    "wof:country":"US",
+    "wof:geomhash":"1fb6f401201e86ea877a13b895f1002f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739929,
+            "country_id":85633793,
+            "locality_id":1209029399
+        }
+    ],
+    "wof:id":1393739929,
+    "wof:lastmodified":1559156964,
+    "wof:name":"Canandaigua Manufactured Home Community",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209029399
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -77.2708,
+    42.88337,
+    -77.2708,
+    42.88337
+],
+  "geometry": {"coordinates":[-77.27079999999999,42.88337],"type":"Point"}
+}

--- a/data/139/373/992/9/1393739929.geojson
+++ b/data/139/373/992/9/1393739929.geojson
@@ -30,8 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        1209029399,
-        85633793
+        102191575,
+        85633793,
+        102082359,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -42,14 +44,18 @@
     "wof:hierarchy":[
         {
             "campus_id":1393739929,
+            "continent_id":102191575,
             "country_id":85633793,
-            "locality_id":1209029399
+            "county_id":102082359,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
+            "region_id":85688543
         }
     ],
     "wof:id":1393739929,
-    "wof:lastmodified":1559156964,
+    "wof:lastmodified":1559168113,
     "wof:name":"Canandaigua Manufactured Home Community",
-    "wof:parent_id":85633793,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/993/1/1393739931.geojson
+++ b/data/139/373/993/1/1393739931.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404511371,
         85633793,
-        1327359443,
-        102087773
+        102087773,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102087773,
-            "localadmin_id":404511371,
-            "locality_id":1327359443,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688727
         }
     ],
     "wof:id":1393739931,
-    "wof:lastmodified":1559156965,
+    "wof:lastmodified":1559168114,
     "wof:name":"Country Lane Manufactured Home Park",
-    "wof:parent_id":404511371,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/993/1/1393739931.geojson
+++ b/data/139/373/993/1/1393739931.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739931,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-94.90972,47.47361,-94.90972,47.47361",
+    "geom:latitude":47.47361,
+    "geom:longitude":-94.90972,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"007",
+    "gn:admin3_code":"5086.0",
+    "gn:asciiname":"Country Lane Manufactured Home Park",
+    "gn:country_code":"US",
+    "gn:dem":417,
+    "gn:elevation":"415.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7121927,
+    "gn:latitude":47.47361,
+    "gn:longitude":-94.90972,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Country Lane Manufactured Home Park",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688727,
+        102191575,
+        404511371,
+        85633793,
+        1327359443,
+        102087773
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7121927
+    },
+    "wof:country":"US",
+    "wof:geomhash":"8b745cc447c4795333503ecd1b108fb1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739931,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087773,
+            "localadmin_id":404511371,
+            "locality_id":1327359443,
+            "region_id":85688727
+        }
+    ],
+    "wof:id":1393739931,
+    "wof:lastmodified":1559156965,
+    "wof:name":"Country Lane Manufactured Home Park",
+    "wof:parent_id":404511371,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1327359443
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -94.90972,
+    47.47361,
+    -94.90972,
+    47.47361
+],
+  "geometry": {"coordinates":[-94.90971999999999,47.47361],"type":"Point"}
+}

--- a/data/139/373/993/3/1393739933.geojson
+++ b/data/139/373/993/3/1393739933.geojson
@@ -30,12 +30,10 @@
     "mz:is_current":-1,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404502743,
         85633793,
-        1226168417,
-        102083429
+        102083429,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -49,15 +47,15 @@
             "continent_id":102191575,
             "country_id":85633793,
             "county_id":102083429,
-            "localadmin_id":404502743,
-            "locality_id":1226168417,
+            "locality_id":-1,
+            "neighbourhood_id":-1,
             "region_id":85688555
         }
     ],
     "wof:id":1393739933,
-    "wof:lastmodified":1559156965,
+    "wof:lastmodified":1559168115,
     "wof:name":"Country Hills Manufactured Home Community",
-    "wof:parent_id":404502743,
+    "wof:parent_id":-1,
     "wof:placetype":"campus",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],

--- a/data/139/373/993/3/1393739933.geojson
+++ b/data/139/373/993/3/1393739933.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1393739933,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-95.09603,39.11466,-95.09603,39.11466",
+    "geom:latitude":39.11466,
+    "geom:longitude":-95.09603,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"103.0",
+    "gn:admin3_code":"70825.0",
+    "gn:asciiname":"Country Hills Manufactured Home Community",
+    "gn:country_code":"US",
+    "gn:dem":284,
+    "gn:elevation":"278.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8122731,
+    "gn:latitude":39.11466,
+    "gn:longitude":-95.09603,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Country Hills Manufactured Home Community",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85688555,
+        102191575,
+        404502743,
+        85633793,
+        1226168417,
+        102083429
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8122731
+    },
+    "wof:country":"US",
+    "wof:geomhash":"ec9cfef137d033d12d4d24f64f76db07",
+    "wof:hierarchy":[
+        {
+            "campus_id":1393739933,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083429,
+            "localadmin_id":404502743,
+            "locality_id":1226168417,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1393739933,
+    "wof:lastmodified":1559156965,
+    "wof:name":"Country Hills Manufactured Home Community",
+    "wof:parent_id":404502743,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226168417
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -95.09603,
+    39.11466,
+    -95.09603,
+    39.11466
+],
+  "geometry": {"coordinates":[-95.09603,39.11466],"type":"Point"}
+}


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1625.

This PR moves 48 "Manufactured *" locality records from Geonames to new campus records. This work includes the same steps as what was completed in https://github.com/whosonfirst-data/whosonfirst-data/issues/1477.

This PR will require PIP work to update the new campus records' hierarchies and parent ids.