### PR TITLE
Fixed spelling in U of Texas record

### DIFF
--- a/data/858/699/79/85869979.geojson
+++ b/data/858/699/79/85869979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000049,
-    "geom:area_square_m":526994.641001,
+    "geom:area_square_m":526994.640997,
     "geom:bbox":"-97.7393313558,30.2798232989,-97.7261352539,30.2887174244",
     "geom:latitude":30.28527,
     "geom:longitude":-97.73311,
@@ -25,16 +25,13 @@
     "mz:tier_locality":5,
     "mz:tier_metro":1,
     "name:eng_x_preferred":[
-        "Universit of Texas"
+        "University of Texas"
     ],
     "name:eng_x_variant":[
         "Universit of Texas"
     ],
     "name:rus_x_preferred":[
         "\u041d\u0430\u0437\u043f\u0435\u0440\u0432\u0435\u0440 \u041a\u0430\u0434\u044b\u043d-\u044d\u0444\u0435\u043d\u0434\u0438"
-    ],
-    "name:unk_x_variant":[
-        "Universit of Texas"
     ],
     "qs:gn_adm0_cc":"US",
     "qs:gn_id":0,
@@ -86,8 +83,8 @@
         }
     ],
     "wof:id":85869979,
-    "wof:lastmodified":1527270466,
-    "wof:name":"Universit of Texas",
+    "wof:lastmodified":1559166722,
+    "wof:name":"University of Texas",
     "wof:parent_id":101724577,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-us",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1626

Updates the `name` and `wof:name` properties in the University of Texas neighbourhood record.