### PR TITLE
Deprecate bunk locality point

### DIFF
--- a/data/136/021/900/1/1360219001.geojson
+++ b/data/136/021/900/1/1360219001.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-07-15",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -24,7 +25,7 @@
     "gn:timezone":"America/Los_Angeles",
     "iso:country":"US",
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
@@ -48,7 +49,7 @@
         }
     ],
     "wof:id":1360219001,
-    "wof:lastmodified":1536752434,
+    "wof:lastmodified":1563228974,
     "wof:name":"Foxhall Ave Henderson NV 89015",
     "wof:parent_id":102081553,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1663

- Deprecates and flags bunk locality point with `mz:is_current` of 0.

No PIP work necessary, can merge once approved.