### PR TITLE
WIP: Update label shortcodes

### DIFF
--- a/data/856/321/63/85632163.geojson
+++ b/data/856/321/63/85632163.geojson
@@ -15,6 +15,9 @@
         "1-671"
     ],
     "itu:region":"1",
+    "label:eng_x_preferred_shortcode":[
+        "GU"
+    ],
     "lbl:latitude":13.427861,
     "lbl:longitude":144.733813,
     "mps:latitude":13.427861,
@@ -708,7 +711,7 @@
         }
     ],
     "wof:id":85632163,
-    "wof:lastmodified":1563401429,
+    "wof:lastmodified":1565645157,
     "wof:name":"Guam",
     "wof:parent_id":136253057,
     "wof:placetype":"dependency",

--- a/data/856/321/69/85632169.geojson
+++ b/data/856/321/69/85632169.geojson
@@ -15,6 +15,9 @@
         "1-340"
     ],
     "itu:region":"1",
+    "label:eng_x_preferred_shortcode":[
+        "VI"
+    ],
     "lbl:latitude":17.73951,
     "lbl:longitude":-64.783592,
     "mps:latitude":17.73951,
@@ -787,7 +790,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1563401427,
+    "wof:lastmodified":1565645157,
     "wof:name":"United States Virgin Islands",
     "wof:parent_id":136253057,
     "wof:placetype":"dependency",

--- a/data/856/323/33/85632333.geojson
+++ b/data/856/323/33/85632333.geojson
@@ -11,6 +11,9 @@
     "geom:longitude":-103.27649,
     "iso:country":"UM",
     "iso:parent":"US",
+    "label:eng_x_preferred_shortcode":[
+        "UM"
+    ],
     "lbl:latitude":19.285663,
     "lbl:longitude":166.644535,
     "mps:latitude":19.285663,
@@ -536,7 +539,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1564119532,
+    "wof:lastmodified":1565645141,
     "wof:name":"United States Minor Outlying Islands",
     "wof:parent_id":136253057,
     "wof:placetype":"dependency",

--- a/data/856/324/21/85632421.geojson
+++ b/data/856/324/21/85632421.geojson
@@ -18,6 +18,9 @@
         "1-670"
     ],
     "itu:region":"1",
+    "label:eng_x_preferred_shortcode":[
+        "MP"
+    ],
     "lbl:latitude":15.193315,
     "lbl:longitude":145.748209,
     "mps:latitude":15.193315,
@@ -724,7 +727,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1563401342,
+    "wof:lastmodified":1565645141,
     "wof:name":"Northern Mariana Islands",
     "wof:parent_id":136253057,
     "wof:placetype":"dependency",

--- a/data/856/326/97/85632697.geojson
+++ b/data/856/326/97/85632697.geojson
@@ -16,6 +16,9 @@
         "1-684"
     ],
     "itu:region":"1",
+    "label:eng_x_preferred_shortcode":[
+        "AS"
+    ],
     "lbl:latitude":-14.333216,
     "lbl:longitude":-170.778926,
     "mps:latitude":-14.333216,
@@ -767,7 +770,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1563401424,
+    "wof:lastmodified":1565645157,
     "wof:name":"American Samoa",
     "wof:parent_id":136253057,
     "wof:placetype":"dependency",

--- a/data/856/337/29/85633729.geojson
+++ b/data/856/337/29/85633729.geojson
@@ -14,6 +14,9 @@
     "itu:country_code":[
         "1"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "PR"
+    ],
     "lbl:latitude":18.234668,
     "lbl:longitude":-66.481065,
     "mps:latitude":18.234668,
@@ -678,7 +681,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1563401224,
+    "wof:lastmodified":1565645116,
     "wof:name":"Puerto Rico",
     "wof:parent_id":136253057,
     "wof:placetype":"dependency",

--- a/data/856/337/93/85633793.geojson
+++ b/data/856/337/93/85633793.geojson
@@ -16,6 +16,9 @@
     "itu:country_code":[
         "1"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "US"
+    ],
     "lbl:bbox":"-124.848973,24.396308,-66.885444,49.384358",
     "lbl:latitude":39.715956,
     "lbl:longitude":-96.999668,
@@ -1460,9 +1463,6 @@
         }
     ],
     "wof:id":85633793,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "eng"
     ],
@@ -1471,7 +1471,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401217,
+    "wof:lastmodified":1565645112,
     "wof:name":"United States",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/884/75/85688475.geojson
+++ b/data/856/884/75/85688475.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "WY"
+    ],
     "label:eng_x_variant_longname":[
         "State of Wyoming",
         "Wyoming State"
@@ -689,7 +692,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401349,
+    "wof:lastmodified":1565645142,
     "wof:name":"Wyoming",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/884/81/85688481.geojson
+++ b/data/856/884/81/85688481.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "PA"
+    ],
     "label:eng_x_variant_longname":[
         "State of Pennsylvania",
         "Pennsylvania State",
@@ -757,7 +760,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401353,
+    "wof:lastmodified":1565645142,
     "wof:name":"Pennsylvania",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/884/85/85688485.geojson
+++ b/data/856/884/85/85688485.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "OH"
+    ],
     "label:eng_x_variant_longname":[
         "State of Ohio",
         "Ohio State"
@@ -731,7 +734,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401357,
+    "wof:lastmodified":1565645143,
     "wof:name":"Ohio",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/884/93/85688493.geojson
+++ b/data/856/884/93/85688493.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NM"
+    ],
     "label:eng_x_variant_longname":[
         "State of New Mexico",
         "New Mexico State"
@@ -753,7 +756,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401346,
+    "wof:lastmodified":1565645141,
     "wof:name":"New Mexico",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/01/85688501.geojson
+++ b/data/856/885/01/85688501.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MD"
+    ],
     "label:eng_x_variant_longname":[
         "State of Maryland",
         "Maryland State"
@@ -719,7 +722,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401389,
+    "wof:lastmodified":1565645149,
     "wof:name":"Maryland",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/09/85688509.geojson
+++ b/data/856/885/09/85688509.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "RI"
+    ],
     "label:eng_x_variant_longname":[
         "State of Rhode Island",
         "Rhode Island State"
@@ -708,7 +711,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401382,
+    "wof:lastmodified":1565645148,
     "wof:name":"Rhode Island",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/13/85688513.geojson
+++ b/data/856/885/13/85688513.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "OR"
+    ],
     "label:eng_x_variant_longname":[
         "State of Oregon",
         "Oregon State"
@@ -706,7 +709,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401417,
+    "wof:lastmodified":1565645155,
     "wof:name":"Oregon",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/17/85688517.geojson
+++ b/data/856/885/17/85688517.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "WI"
+    ],
     "label:eng_x_variant_longname":[
         "State of Wisconsin",
         "Wisconsin State"
@@ -716,7 +719,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401376,
+    "wof:lastmodified":1565645147,
     "wof:name":"Wisconsin",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/25/85688525.geojson
+++ b/data/856/885/25/85688525.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "ND"
+    ],
     "label:eng_x_variant_longname":[
         "State of North Dakota",
         "North Dakota State"
@@ -719,7 +722,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401421,
+    "wof:lastmodified":1565645155,
     "wof:name":"North Dakota",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/31/85688531.geojson
+++ b/data/856/885/31/85688531.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NV"
+    ],
     "label:eng_x_variant_longname":[
         "State of Nevada",
         "Nevada State"
@@ -709,7 +712,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401385,
+    "wof:lastmodified":1565645149,
     "wof:name":"Nevada",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/35/85688535.geojson
+++ b/data/856/885/35/85688535.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "GA"
+    ],
     "label:eng_x_variant_longname":[
         "State of Georgia",
         "Georgia State"
@@ -758,7 +761,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401359,
+    "wof:lastmodified":1565645144,
     "wof:name":"Georgia",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/43/85688543.geojson
+++ b/data/856/885/43/85688543.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NY"
+    ],
     "label:eng_x_variant_longname":[
         "State of New York",
         "New York State"
@@ -803,7 +806,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401379,
+    "wof:lastmodified":1565645148,
     "wof:name":"New York",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/49/85688549.geojson
+++ b/data/856/885/49/85688549.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AR"
+    ],
     "label:eng_x_variant_longname":[
         "State of Arkansas",
         "Arkansas State"
@@ -710,7 +713,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401413,
+    "wof:lastmodified":1565645154,
     "wof:name":"Arkansas",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/55/85688555.geojson
+++ b/data/856/885/55/85688555.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KS"
+    ],
     "label:eng_x_variant_longname":[
         "State of Kansas",
         "Kansas State"
@@ -737,7 +740,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401397,
+    "wof:lastmodified":1565645151,
     "wof:name":"Kansas",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/63/85688563.geojson
+++ b/data/856/885/63/85688563.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NE"
+    ],
     "label:eng_x_variant_longname":[
         "State of Nebraska",
         "Nebraska State"
@@ -716,7 +719,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401401,
+    "wof:lastmodified":1565645151,
     "wof:name":"Nebraska",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/67/85688567.geojson
+++ b/data/856/885/67/85688567.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "UT"
+    ],
     "label:eng_x_variant_longname":[
         "State of Utah",
         "Utah State"
@@ -706,7 +709,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401364,
+    "wof:lastmodified":1565645145,
     "wof:name":"Utah",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/73/85688573.geojson
+++ b/data/856/885/73/85688573.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AK"
+    ],
     "label:eng_x_variant_longname":[
         "State of Alaska",
         "Alaska State"
@@ -788,7 +791,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401372,
+    "wof:lastmodified":1565645147,
     "wof:name":"Alaska",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/79/85688579.geojson
+++ b/data/856/885/79/85688579.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MS"
+    ],
     "label:eng_x_variant_longname":[
         "State of Mississippi",
         "Mississippi State"
@@ -699,7 +702,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401404,
+    "wof:lastmodified":1565645152,
     "wof:name":"Mississippi",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/85/85688585.geojson
+++ b/data/856/885/85/85688585.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "OK"
+    ],
     "label:eng_x_variant_longname":[
         "State of Oklahoma",
         "Oklahoma State"
@@ -706,7 +709,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401409,
+    "wof:lastmodified":1565645153,
     "wof:name":"Oklahoma",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/89/85688589.geojson
+++ b/data/856/885/89/85688589.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "WV"
+    ],
     "label:eng_x_variant_longname":[
         "State of West Virginia",
         "West Virginia State"
@@ -740,7 +743,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401367,
+    "wof:lastmodified":1565645145,
     "wof:name":"West Virginia",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/885/99/85688599.geojson
+++ b/data/856/885/99/85688599.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MI"
+    ],
     "label:eng_x_variant_longname":[
         "State of Michigan",
         "Michigan State"
@@ -705,7 +708,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401393,
+    "wof:lastmodified":1565645150,
     "wof:name":"Michigan",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/03/85688603.geojson
+++ b/data/856/886/03/85688603.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "CO"
+    ],
     "label:eng_x_variant_longname":[
         "State of Colorado",
         "Colorado State"
@@ -734,7 +737,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401286,
+    "wof:lastmodified":1565645132,
     "wof:name":"Colorado",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/07/85688607.geojson
+++ b/data/856/886/07/85688607.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NJ"
+    ],
     "label:eng_x_variant_longname":[
         "State of New Jersey",
         "New Jersey State"
@@ -762,7 +765,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401319,
+    "wof:lastmodified":1565645137,
     "wof:name":"New Jersey",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/11/85688611.geojson
+++ b/data/856/886/11/85688611.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "DE"
+    ],
     "label:eng_x_variant_longname":[
         "State of Delaware",
         "Delaware State"
@@ -698,7 +701,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401297,
+    "wof:lastmodified":1565645135,
     "wof:name":"Delaware",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/17/85688617.geojson
+++ b/data/856/886/17/85688617.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MT"
+    ],
     "label:eng_x_variant_longname":[
         "State of Montana",
         "Montana State"
@@ -700,7 +703,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401311,
+    "wof:lastmodified":1565645136,
     "wof:name":"Montana",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/23/85688623.geojson
+++ b/data/856/886/23/85688623.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "WA"
+    ],
     "label:eng_x_variant_longname":[
         "State of Washington",
         "Washington State"
@@ -729,7 +732,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401336,
+    "wof:lastmodified":1565645141,
     "wof:name":"Washington",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/29/85688629.geojson
+++ b/data/856/886/29/85688629.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "CT"
+    ],
     "label:eng_x_variant_longname":[
         "State of Connecticut",
         "Connecticut State"
@@ -736,7 +739,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401301,
+    "wof:lastmodified":1565645135,
     "wof:name":"Connecticut",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/37/85688637.geojson
+++ b/data/856/886/37/85688637.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "CA"
+    ],
     "label:eng_x_variant_longname":[
         "State of California",
         "California State"
@@ -796,7 +799,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401322,
+    "wof:lastmodified":1565645138,
     "wof:name":"California",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/41/85688641.geojson
+++ b/data/856/886/41/85688641.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "KY"
+    ],
     "label:eng_x_variant_longname":[
         "State of Kentucky",
         "Kentucky State",
@@ -718,7 +721,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401330,
+    "wof:lastmodified":1565645139,
     "wof:name":"Kentucky",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/45/85688645.geojson
+++ b/data/856/886/45/85688645.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MA"
+    ],
     "label:eng_x_variant_longname":[
         "State of Massachusetts",
         "Massachusetts State",
@@ -718,7 +721,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401307,
+    "wof:lastmodified":1565645136,
     "wof:name":"Massachusetts",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/51/85688651.geojson
+++ b/data/856/886/51/85688651.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "FL"
+    ],
     "label:eng_x_variant_longname":[
         "State of Florida",
         "Florida State"
@@ -737,7 +740,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401290,
+    "wof:lastmodified":1565645133,
     "wof:name":"Florida",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/57/85688657.geojson
+++ b/data/856/886/57/85688657.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "ID"
+    ],
     "label:eng_x_variant_longname":[
         "State of Idaho",
         "Idaho State"
@@ -710,7 +713,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401281,
+    "wof:lastmodified":1565645131,
     "wof:name":"Idaho",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/61/85688661.geojson
+++ b/data/856/886/61/85688661.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MO"
+    ],
     "label:eng_x_variant_longname":[
         "State of Missouri",
         "Missouri State"
@@ -757,7 +760,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401277,
+    "wof:lastmodified":1565645130,
     "wof:name":"Missouri",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/71/85688671.geojson
+++ b/data/856/886/71/85688671.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "HI"
+    ],
     "label:eng_x_variant_longname":[
         "State of Hawaii",
         "Hawaii State"
@@ -766,7 +769,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401340,
+    "wof:lastmodified":1565645141,
     "wof:name":"Hawaii",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/75/85688675.geojson
+++ b/data/856/886/75/85688675.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AL"
+    ],
     "label:eng_x_variant_longname":[
         "State of Alabama",
         "Alabama State"
@@ -766,7 +769,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401315,
+    "wof:lastmodified":1565645137,
     "wof:name":"Alabama",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/83/85688683.geojson
+++ b/data/856/886/83/85688683.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SC"
+    ],
     "label:eng_x_variant_longname":[
         "State of South Carolina",
         "South Carolina State"
@@ -728,7 +731,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401334,
+    "wof:lastmodified":1565645140,
     "wof:name":"South Carolina",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/89/85688689.geojson
+++ b/data/856/886/89/85688689.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NH"
+    ],
     "label:eng_x_variant_longname":[
         "State of New Hampshire",
         "New Hampshire State"
@@ -722,7 +725,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401304,
+    "wof:lastmodified":1565645135,
     "wof:name":"New Hampshire",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/93/85688693.geojson
+++ b/data/856/886/93/85688693.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "SD"
+    ],
     "label:eng_x_variant_longname":[
         "State of South Dakota",
         "South Dakota State"
@@ -716,7 +719,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401294,
+    "wof:lastmodified":1565645134,
     "wof:name":"South Dakota",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/886/97/85688697.geojson
+++ b/data/856/886/97/85688697.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "IL"
+    ],
     "label:eng_x_variant_longname":[
         "State of Illinois",
         "Illinois State"
@@ -755,7 +758,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401326,
+    "wof:lastmodified":1565645138,
     "wof:name":"Illinois",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/01/85688701.geojson
+++ b/data/856/887/01/85688701.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "TN"
+    ],
     "label:eng_x_variant_longname":[
         "State of Tennessee",
         "Tennessee State"
@@ -723,7 +726,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401259,
+    "wof:lastmodified":1565645125,
     "wof:name":"Tennessee",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/09/85688709.geojson
+++ b/data/856/887/09/85688709.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "IN"
+    ],
     "label:eng_x_variant_longname":[
         "State of Indiana",
         "Indiana State"
@@ -716,7 +719,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401248,
+    "wof:lastmodified":1565645121,
     "wof:name":"Indiana",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/13/85688713.geojson
+++ b/data/856/887/13/85688713.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "IA"
+    ],
     "label:eng_x_variant_longname":[
         "State of Iowa",
         "Iowa State"
@@ -710,7 +713,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401273,
+    "wof:lastmodified":1565645129,
     "wof:name":"Iowa",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/19/85688719.geojson
+++ b/data/856/887/19/85688719.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "AZ"
+    ],
     "label:eng_x_variant_longname":[
         "State of Arizona",
         "Arizona State"
@@ -740,7 +743,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401245,
+    "wof:lastmodified":1565645121,
     "wof:name":"Arizona",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/27/85688727.geojson
+++ b/data/856/887/27/85688727.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "MN"
+    ],
     "label:eng_x_variant_longname":[
         "State of Minnesota",
         "Minnesota State"
@@ -703,7 +706,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401236,
+    "wof:lastmodified":1565645118,
     "wof:name":"Minnesota",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/35/85688735.geojson
+++ b/data/856/887/35/85688735.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "LA"
+    ],
     "label:eng_x_variant_longname":[
         "State of Louisiana",
         "Louisiana State"
@@ -734,7 +737,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401227,
+    "wof:lastmodified":1565645116,
     "wof:name":"Louisiana",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/41/85688741.geojson
+++ b/data/856/887/41/85688741.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "federal district"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "DC"
+    ],
     "lbl:latitude":38.912097,
     "lbl:longitude":-77.014683,
     "mps:latitude":38.912097,
@@ -853,7 +856,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401264,
+    "wof:lastmodified":1565645127,
     "wof:name":"District of Columbia",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/47/85688747.geojson
+++ b/data/856/887/47/85688747.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "VA"
+    ],
     "label:eng_x_variant_longname":[
         "State of Virginia",
         "Virginia State",
@@ -712,7 +715,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401268,
+    "wof:lastmodified":1565645127,
     "wof:name":"Virginia",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/53/85688753.geojson
+++ b/data/856/887/53/85688753.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "TX"
+    ],
     "label:eng_x_variant_longname":[
         "State of Texas",
         "Texas State"
@@ -761,7 +764,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401253,
+    "wof:lastmodified":1565645122,
     "wof:name":"Texas",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/63/85688763.geojson
+++ b/data/856/887/63/85688763.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "VT"
+    ],
     "label:eng_x_variant_longname":[
         "State of Vermont",
         "Vermont State"
@@ -714,7 +717,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401263,
+    "wof:lastmodified":1565645126,
     "wof:name":"Vermont",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/69/85688769.geojson
+++ b/data/856/887/69/85688769.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "ME"
+    ],
     "label:eng_x_variant_longname":[
         "State of Maine",
         "Maine State"
@@ -698,7 +701,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401232,
+    "wof:lastmodified":1565645117,
     "wof:name":"Maine",
     "wof:parent_id":85633793,
     "wof:placetype":"region",

--- a/data/856/887/73/85688773.geojson
+++ b/data/856/887/73/85688773.geojson
@@ -20,6 +20,9 @@
     "label:eng_x_preferred_placetype":[
         "state"
     ],
+    "label:eng_x_preferred_shortcode":[
+        "NC"
+    ],
     "label:eng_x_variant_longname":[
         "State of North Carolina",
         "North Carolina State"
@@ -725,7 +728,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1563401241,
+    "wof:lastmodified":1565645120,
     "wof:name":"North Carolina",
     "wof:parent_id":85633793,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1689.

- Adds a `label:eng_x_preferred_shortcode` property to any country, macroregion, region, or dependency record
- Removes any `wof:lang` property if `wof:lang_x_official` and `wof:lang_x_spoken` properties are present

Will not require PIP work, property edits only.

Script output:

```
whosonfirst-data-admin-us
85633793,US
85633729,PR
85688735,LA
85688769,ME
85688727,MN
85688773,NC
85688719,AZ
85688709,IN
85688753,TX
85688701,TN
85688763,VT
85688741,DC
85688747,VA
85688713,IA
85688661,MO
85688657,ID
85688603,CO
85688651,FL
85688693,SD
85688611,DE
85688629,CT
85688689,NH
85688645,MA
85688617,MT
85688675,AL
85688607,NJ
85688637,CA
85688697,IL
85688641,KY
85688683,SC
85688623,WA
85688671,HI
85632421,MP
85632333,UM
85688493,NM
85688475,WY
85688481,PA
85688485,OH
85688535,GA
85688567,UT
85688589,WV
85688573,AK
85688517,WI
85688543,NY
85688509,RI
85688531,NV
85688501,MD
85688599,MI
85688555,KS
85688563,NE
85688579,MS
85688585,OK
85688549,AR
85688513,OR
85688525,ND
85632697,AS
85632649 doesnt have label shortcode..(Guantanamo Bay USNB)
85632169,VI
85632163,GU
```