### PR TITLE
Update Flatiron, NYC records

### DIFF
--- a/data/858/657/09/85865709.geojson
+++ b/data/858/657/09/85865709.geojson
@@ -2,7 +2,7 @@
   "id": 85865709,
   "type": "Feature",
   "properties": {
-    "edtf:cessation":"uuuu",
+    "edtf:cessation":"2019-09-09",
     "edtf:inception":"uuuu",
     "geom:area":0.000016,
     "geom:area_square_m":149878.441664,
@@ -16,7 +16,7 @@
     "mps:latitude":40.746165,
     "mps:longitude":-73.984072,
     "mz:hierarchy_label":1,
-    "mz:is_current":1,
+    "mz:is_current":0,
     "mz:is_funky":1,
     "mz:is_hard_boundary":0,
     "mz:is_landuse_aoi":0,
@@ -101,12 +101,14 @@
         }
     ],
     "wof:id":85865709,
-    "wof:lastmodified":1566616375,
+    "wof:lastmodified":1568052708,
     "wof:name":"Flatiron",
     "wof:parent_id":85975297,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        85869245
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/858/692/45/85869245.geojson
+++ b/data/858/692/45/85869245.geojson
@@ -148,13 +148,15 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566616268,
+    "wof:lastmodified":1568052713,
     "wof:name":"Flatiron District",
     "wof:parent_id":907215781,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        85865709
+    ],
     "wof:tags":[]
 },
   "bbox": [


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1704

- Updates 85869245 to supersede 85865709
- Flags 85865709 as not current and deprecated

No PIP required, can merge once approved.