### PR TITLE
Update names for Draffenville, KY

### DIFF
--- a/data/112/578/000/9/1125780009.geojson
+++ b/data/112/578/000/9/1125780009.geojson
@@ -23,10 +23,10 @@
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:eng_x_preferred":[
-        "Daffenville"
+        "Draffenville"
     ],
     "name:eng_x_variant":[
-        "Draffenville"
+        "Daffenville"
     ],
     "name:fra_x_preferred":[
         "Draffenville"
@@ -89,8 +89,8 @@
         }
     ],
     "wof:id":1125780009,
-    "wof:lastmodified":1566638707,
-    "wof:name":"Daffenville",
+    "wof:lastmodified":1568058273,
+    "wof:name":"Draffenville",
     "wof:parent_id":102084509,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1700.

- Updates names for the record of Draffenville, KY.

Does not require PIP work, can merge once approved.

See: https://en.wikipedia.org/wiki/Draffenville,_Kentucky