### PR TITLE
Update names for Oakland

### DIFF
--- a/data/859/218/81/85921881.geojson
+++ b/data/859/218/81/85921881.geojson
@@ -28,7 +28,6 @@
     "name:afr_x_preferred":[
         "Oakland"
     ],
-    "name:ara_x_colloquial":[],
     "name:ara_x_preferred":[
         "\u0623\u0648\u0643\u0644\u0627\u0646\u062f"
     ],
@@ -50,21 +49,18 @@
     "name:bam_x_preferred":[
         "Oakland"
     ],
-    "name:bel_x_colloquial":[],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041e\u043a\u043b\u0435\u043d\u0434"
     ],
     "name:bel_x_variant":[
         "\u041e\u043a\u043b\u0435\u043d\u0434"
     ],
-    "name:ben_x_colloquial":[],
     "name:ben_x_preferred":[
         "\u0993\u0995\u09b2\u09cd\u09af\u09be\u09a8\u09cd\u09a1"
     ],
     "name:bre_x_preferred":[
         "Oakland"
     ],
-    "name:bul_x_colloquial":[],
     "name:bul_x_preferred":[
         "\u041e\u043a\u043b\u0430\u043d\u0434"
     ],
@@ -86,15 +82,12 @@
     "name:cym_x_preferred":[
         "Oakland"
     ],
-    "name:dan_x_colloquial":[],
     "name:dan_x_preferred":[
         "Oakland"
     ],
-    "name:deu_x_colloquial":[],
     "name:deu_x_preferred":[
         "Oakland"
     ],
-    "name:ell_x_colloquial":[],
     "name:ell_x_preferred":[
         "\u038c\u03bf\u03c5\u03ba\u03bb\u03b1\u03bd\u03c4"
     ],
@@ -118,30 +111,22 @@
     "name:eus_x_preferred":[
         "Oakland"
     ],
-    "name:fas_x_colloquial":[],
     "name:fas_x_preferred":[
         "\u0627\u0648\u06a9\u0644\u0646\u062f"
     ],
-    "name:fin_x_colloquial":[],
     "name:fin_x_preferred":[
         "Oakland"
     ],
     "name:fit_x_preferred":[
         "Oakland"
     ],
-    "name:fra_x_colloquial":[],
     "name:fra_x_preferred":[
         "Oakland"
     ],
-    "name:fre_x_colloquial":[],
-    "name:fre_x_variant":[
+    "name:fra_x_variant":[
         "Oakland"
     ],
     "name:fry_x_preferred":[
-        "Oakland"
-    ],
-    "name:ger_x_colloquial":[],
-    "name:ger_x_variant":[
         "Oakland"
     ],
     "name:gla_x_preferred":[
@@ -153,23 +138,16 @@
     "name:glg_x_preferred":[
         "Oakland"
     ],
-    "name:gre_x_colloquial":[],
-    "name:gre_x_variant":[
-        "\u038c\u03bf\u03c5\u03ba\u03bb\u03b1\u03bd\u03c4"
-    ],
     "name:guj_x_preferred":[
         "\u0a93\u0a95\u0ab2\u0ac7\u0aa8\u0acd\u0aa1"
     ],
     "name:hat_x_preferred":[
         "Oakland"
     ],
-    "name:heb_x_colloquial":[],
     "name:heb_x_preferred":[
         "\u05d0\u05d5\u05e7\u05dc\u05e0\u05d3"
     ],
-    "name:hin_x_colloquial":[],
-    "name:hin_x_preferred":[],
-    "name:hin_x_variant":[
+    "name:hin_x_preferred":[
         "\u0913\u0915\u0932\u0948\u0902\u0921"
     ],
     "name:hrv_x_preferred":[
@@ -178,7 +156,6 @@
     "name:hun_x_preferred":[
         "Oakland"
     ],
-    "name:hye_x_colloquial":[],
     "name:hye_x_preferred":[
         "\u0555\u0584\u056c\u0565\u0576\u0564"
     ],
@@ -194,47 +171,36 @@
     "name:ind_x_preferred":[
         "Oakland"
     ],
-    "name:isl_x_colloquial":[],
     "name:isl_x_preferred":[
         "Oakland"
     ],
-    "name:ita_x_colloquial":[],
     "name:ita_x_preferred":[
         "Oakland"
     ],
-    "name:jap_x_colloquial":[],
-    "name:jap_x_preferred":[],
-    "name:jap_x_variant":[],
     "name:jav_x_preferred":[
         "Oakland"
     ],
-    "name:jpn_x_colloquial":[],
     "name:jpn_x_preferred":[
         "\u30aa\u30fc\u30af\u30e9\u30f3\u30c9"
     ],
     "name:kan_x_preferred":[
         "\u0c93\u0c95\u0ccd\u0cb2\u0ccd\u0caf\u0cbe\u0c82\u0ca1\u0ccd"
     ],
-    "name:kat_x_colloquial":[],
     "name:kat_x_preferred":[
         "\u10dd\u10d9\u10da\u10d4\u10dc\u10d3\u10d8"
     ],
-    "name:kor_x_colloquial":[],
     "name:kor_x_preferred":[
         "\uc624\ud074\ub79c\ub4dc"
     ],
-    "name:lat_x_colloquial":[],
     "name:lat_x_preferred":[
         "Quercupolis"
     ],
-    "name:lav_x_colloquial":[],
     "name:lav_x_preferred":[
         "Oklenda"
     ],
     "name:lim_x_preferred":[
         "Oakland"
     ],
-    "name:lit_x_colloquial":[],
     "name:lit_x_preferred":[
         "Oklandas"
     ],
@@ -247,18 +213,15 @@
     "name:mal_x_preferred":[
         "\u0d13\u0d15\u0d4d\u0d7f\u0d32\u0d3e\u0d28\u0d4d\u0d31\u0d4d"
     ],
-    "name:mar_x_colloquial":[],
     "name:mar_x_preferred":[
         "\u0913\u0915\u0932\u0902\u0921"
     ],
-    "name:mkd_x_colloquial":[],
     "name:mkd_x_preferred":[
         "\u041e\u0443\u043a\u043b\u0435\u043d\u0434"
     ],
     "name:mlg_x_preferred":[
         "Oakland"
     ],
-    "name:mrj_x_colloquial":[],
     "name:mrj_x_preferred":[
         "\u041e\u043a\u043b\u0435\u043d\u0434"
     ],
@@ -274,23 +237,18 @@
     "name:nav_x_preferred":[
         "Ch\u00e9ch\u02bciltah Hatsoh"
     ],
-    "name:nep_x_colloquial":[],
     "name:nep_x_preferred":[
         "\u0913\u0915\u0932\u094d\u092f\u093e\u0923\u094d\u0921"
     ],
-    "name:new_x_colloquial":[],
     "name:new_x_preferred":[
         "\u0913\u0915\u0932\u094d\u092f\u093e\u0928\u094d\u0921"
     ],
-    "name:nld_x_colloquial":[],
     "name:nld_x_preferred":[
         "Oakland"
     ],
-    "name:nno_x_colloquial":[],
     "name:nno_x_preferred":[
         "Oakland i California"
     ],
-    "name:nno_x_variant":[],
     "name:nob_x_preferred":[
         "Oakland"
     ],
@@ -303,26 +261,21 @@
     "name:pms_x_preferred":[
         "Oakland"
     ],
-    "name:pnb_x_colloquial":[],
     "name:pnb_x_preferred":[
         "\u0627\u0648\u06a9\u0644\u06cc\u0646\u0688"
     ],
-    "name:pol_x_colloquial":[],
     "name:pol_x_preferred":[
         "Oakland"
     ],
-    "name:por_x_colloquial":[],
     "name:por_x_preferred":[
         "Oakland"
     ],
     "name:ron_x_preferred":[
         "Oakland"
     ],
-    "name:rus_x_colloquial":[],
     "name:rus_x_preferred":[
         "\u041e\u043a\u043b\u0435\u043d\u0434"
     ],
-    "name:sah_x_colloquial":[],
     "name:sah_x_preferred":[
         "\u041e\u043a\u043b\u0435\u043d\u0434"
     ],
@@ -341,28 +294,24 @@
     "name:som_x_preferred":[
         "Oakland"
     ],
-    "name:spa_x_colloquial":[],
     "name:spa_x_preferred":[
         "Oakland"
     ],
     "name:sqi_x_preferred":[
         "Oakland"
     ],
-    "name:srp_x_colloquial":[],
     "name:srp_x_preferred":[
         "\u041e\u0443\u043a\u043b\u0430\u043d\u0434"
     ],
     "name:swa_x_preferred":[
         "Oakland"
     ],
-    "name:swe_x_colloquial":[],
     "name:swe_x_preferred":[
         "Oakland"
     ],
     "name:szl_x_preferred":[
         "Oakland"
     ],
-    "name:tam_x_colloquial":[],
     "name:tam_x_preferred":[
         "\u0b93\u0b95\u0bcd\u0bb2\u0ba3\u0bcd\u0b9f\u0bcd"
     ],
@@ -378,16 +327,12 @@
     "name:tha_x_preferred":[
         "\u0e42\u0e2d\u0e4a\u0e01\u0e41\u0e25\u0e19\u0e14\u0e4c"
     ],
-    "name:tur_x_colloquial":[],
-    "name:tur_x_preferred":[],
-    "name:tur_x_variant":[
+    "name:tur_x_preferred":[
         "Oakland"
     ],
-    "name:ukr_x_colloquial":[],
     "name:ukr_x_preferred":[
         "\u041e\u043a\u043b\u0435\u043d\u0434"
     ],
-    "name:urd_x_colloquial":[],
     "name:urd_x_preferred":[
         "\u0627\u0648\u06a9\u0644\u06cc\u0646\u0688\u060c \u06a9\u06cc\u0644\u06cc\u0641\u0648\u0631\u0646\u06cc\u0627"
     ],
@@ -397,9 +342,7 @@
     "name:uzb_x_preferred":[
         "Oakland"
     ],
-    "name:vie_x_colloquial":[],
-    "name:vie_x_preferred":[],
-    "name:vie_x_variant":[
+    "name:vie_x_preferred":[
         "Oakland"
     ],
     "name:vol_x_preferred":[
@@ -408,18 +351,15 @@
     "name:war_x_preferred":[
         "Oakland"
     ],
-    "name:yid_x_colloquial":[],
     "name:yid_x_preferred":[
         "\u05d0\u05e7\u05dc\u05d0\u05e0\u05d3"
     ],
     "name:yor_x_preferred":[
         "Oakland"
     ],
-    "name:yue_x_colloquial":[],
     "name:yue_x_preferred":[
         "\u5967\u514b\u862d"
     ],
-    "name:zho_x_colloquial":[],
     "name:zho_x_preferred":[
         "\u5965\u514b\u5170"
     ],
@@ -565,7 +505,7 @@
         }
     ],
     "wof:id":85921881,
-    "wof:lastmodified":1566611826,
+    "wof:lastmodified":1568225030,
     "wof:megacity":0,
     "wof:name":"Oakland",
     "wof:parent_id":102086959,


### PR DESCRIPTION
Fixes the US portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1709

This PR removes any bunk iso codes/name properties and empty name lists. Unfortunately, the Git history does not reveal where these empty name strings come from. I also ran this record against wikidata to gain new names, but no new names were found.

This does not require PIP work. Can be merged once approved.