### PR TITLE
Fix names for three records in US

### DIFF
--- a/data/858/659/39/85865939.geojson
+++ b/data/858/659/39/85865939.geojson
@@ -35,13 +35,13 @@
         "SOMA"
     ],
     "name:eng_x_preferred":[
-        "South Of Market"
+        "South of Market"
     ],
     "name:eng_x_variant":[
         "S of Market",
         "Soma",
         "SOMA",
-        "South of Market"
+        "South Of Market"
     ],
     "name:fra_x_preferred":[
         "South of Market"
@@ -124,8 +124,8 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566616261,
-    "wof:name":"Soma",
+    "wof:lastmodified":1574288402,
+    "wof:name":"South of Market",
     "wof:parent_id":85922583,
     "wof:placetype":"neighbourhood",
     "wof:population":8451,

--- a/data/858/933/71/85893371.geojson
+++ b/data/858/933/71/85893371.geojson
@@ -12,7 +12,6 @@
     "geom:bbox":"-75.1753998262,39.895520345,-75.1478266426,39.91673694",
     "geom:latitude":39.905945,
     "geom:longitude":-75.161584,
-    "gn:id":"",
     "iso:country":"US",
     "lbl:latitude":39.904185,
     "lbl:longitude":-75.168384,
@@ -108,11 +107,11 @@
         "\u03c3\u03c4\u03ac\u03b4\u03b9\u03bf"
     ],
     "name:eng_x_preferred":[
-        "Stadiums"
+        "Stadium District"
     ],
     "name:eng_x_variant":[
-        "Stadium District",
-        "stadium"
+        "stadium",
+        "Stadiums"
     ],
     "name:epo_x_preferred":[
         "Stadiono"
@@ -422,8 +421,8 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566617890,
-    "wof:name":"Stadiums",
+    "wof:lastmodified":1574288390,
+    "wof:name":"Stadium District",
     "wof:parent_id":1108721801,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-us",

--- a/data/859/440/27/85944027.geojson
+++ b/data/859/440/27/85944027.geojson
@@ -45,11 +45,11 @@
         "West Des Moines"
     ],
     "name:eng_x_preferred":[
-        "West des Moines"
+        "West Des Moines"
     ],
     "name:eng_x_variant":[
         "W des Moines",
-        "West Des Moines"
+        "West des Moines"
     ],
     "name:eus_x_preferred":[
         "West Des Moines"
@@ -197,7 +197,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566611741,
+    "wof:lastmodified":1574288393,
     "wof:name":"West Des Moines",
     "wof:parent_id":102086603,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1743.

- Updates names in "South of Market" neighbourhood record, stored existing as variants
- Updates names in "Stadium District" neighbourhood record, stored existing as variants
- Updates names in "West Des Moines" locality record, stored existing as variants

No PIP work required, can merge once approved.