### PR TITLE
remove "ne" shortcode from new york county

### DIFF
--- a/data/102/081/863/102081863.geojson
+++ b/data/102/081/863/102081863.geojson
@@ -127,7 +127,6 @@
     "wof:population":1585873,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:shortcode":"NE",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]


### PR DESCRIPTION
I noticed this while playing with NYC queries in pelias/ES. It seems wrong to me. I don't know why this is here - it's super non-standard and not used anywhere I know of as a 35 year resident of NYC and 10+ yr geospatial developer.

"BK" on kings county makes some sense.  staten island and queens don't have. Bronx has "BN" which is also weird and I'd expect it to be "BX" or missing