### PR TITLE
Fix dup KC records

### DIFF
--- a/data/114/190/916/1/1141909161.geojson
+++ b/data/114/190/916/1/1141909161.geojson
@@ -3,10 +3,11 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-04-01",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-94.6060400775,39.1090343684,-94.6060400775,39.1090343684",
+    "geom:bbox":"-94.60604,39.109034,-94.60604,39.109034",
     "geom:latitude":39.109034,
     "geom:longitude":-94.60604,
     "iso:country":"US",
@@ -16,7 +17,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"United States of America",
@@ -125,7 +126,7 @@
     "wof:concordances":{},
     "wof:country":"US",
     "wof:created":1499131035,
-    "wof:geomhash":"d46a1650eb010a3a50a1c4f942fb90e6",
+    "wof:geomhash":"554009279d92ff39eaf1db717fd66807",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -137,20 +138,22 @@
         }
     ],
     "wof:id":1141909161,
-    "wof:lastmodified":1566643000,
+    "wof:lastmodified":1585788837,
     "wof:name":"Kansas City",
     "wof:parent_id":404518075,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        85970739
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -94.6060400775458,
-    39.10903436839749,
-    -94.6060400775458,
-    39.10903436839749
+    -94.60604,
+    39.109034,
+    -94.60604,
+    39.109034
 ],
-  "geometry": {"coordinates":[-94.6060400775458,39.10903436839749],"type":"Point"}
+  "geometry": {"coordinates":[-94.60603999999999,39.109034],"type":"Point"}
 }

--- a/data/859/707/39/85970739.geojson
+++ b/data/859/707/39/85970739.geojson
@@ -324,14 +324,15 @@
         }
     ],
     "wof:id":85970739,
-    "wof:lastmodified":1582335551,
+    "wof:lastmodified":1585788784,
     "wof:name":"Kansas City",
     "wof:parent_id":404518075,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],
     "wof:supersedes":[
-        1125408625
+        1125408625,
+        1141909161
     ],
     "wof:tags":[]
 },


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1791.

Supersedes a duplicate Kansas City locality record into the Kansas City locality record with a polygon geometry (and full set of properties). No properties to bring over, can merge without PIP work.