### PR TITLE
Move locality points to campus

### DIFF
--- a/data/119/303/570/3/1193035703.geojson
+++ b/data/119/303/570/3/1193035703.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.65917,40.95889,-82.65917,40.95889",
@@ -30,22 +32,22 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404525921,
         85633793,
-        102083681
+        102083681,
+        404525921,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7235459
     },
     "wof:country":"US",
-    "wof:geomhash":"53e313af73ba4c2b09e7fae1b012cb78",
+    "wof:geomhash":"e0ded1f2e7cf08ac860f653db393ab87",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -57,20 +59,22 @@
         }
     ],
     "wof:id":1193035703,
-    "wof:lastmodified":1566623391,
+    "wof:lastmodified":1588726990,
     "wof:name":"Pine Grove Mobile Estates",
     "wof:parent_id":404525921,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118475
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -82.65916999999997,
+    -82.65917,
     40.95889,
-    -82.65916999999997,
+    -82.65917,
     40.95889
 ],
-  "geometry": {"coordinates":[-82.65916999999997,40.95889],"type":"Point"}
+  "geometry": {"coordinates":[-82.65917,40.95889],"type":"Point"}
 }

--- a/data/119/314/798/1/1193147981.geojson
+++ b/data/119/314/798/1/1193147981.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-117.87441,48.45318,-117.87441,48.45318",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102085373
+        102085373,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1193147981,
-    "wof:lastmodified":1566623320,
+    "wof:lastmodified":1588726990,
     "wof:name":"Country Villa Mobile Estates",
     "wof:parent_id":102085373,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118477
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/119/317/220/9/1193172209.geojson
+++ b/data/119/317/220/9/1193172209.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-121.73806,38.54222,-121.73806,38.54222",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102082309
+        102082309,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1193172209,
-    "wof:lastmodified":1566623484,
+    "wof:lastmodified":1588726990,
     "wof:name":"Davis Mobile Estates",
     "wof:parent_id":102082309,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118471
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/901/572/1/1209015721.geojson
+++ b/data/120/901/572/1/1209015721.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.8828,26.6941,-81.8828,26.6941",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209015721,
-    "wof:lastmodified":1566622028,
+    "wof:lastmodified":1588726988,
     "wof:name":"Buccaneer Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118431
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/902/382/7/1209023827.geojson
+++ b/data/120/902/382/7/1209023827.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-96.58944,46.25444,-96.58944,46.25444",
@@ -30,7 +32,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -49,12 +51,14 @@
         }
     ],
     "wof:id":1209023827,
-    "wof:lastmodified":1566622709,
+    "wof:lastmodified":1588726988,
     "wof:name":"Boise De Sioux Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118429
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/902/934/1/1209029341.geojson
+++ b/data/120/902/934/1/1209029341.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-123.57315,46.98306,-123.57315,46.98306",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209029341,
-    "wof:lastmodified":1566622721,
+    "wof:lastmodified":1588726988,
     "wof:name":"Evergreen Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118405
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/912/246/3/1209122463.geojson
+++ b/data/120/912/246/3/1209122463.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-105.8375,46.4125,-105.8375,46.4125",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
         "Westwood Estates"
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1209122463,
-    "wof:lastmodified":1566622309,
+    "wof:lastmodified":1588726989,
     "wof:name":"Westwood Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118463
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/942/590/7/1209425907.geojson
+++ b/data/120/942/590/7/1209425907.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.19005,47.81056,-122.19005,47.81056",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209425907,
-    "wof:lastmodified":1566622970,
+    "wof:lastmodified":1588726987,
     "wof:name":"Cascade Vista Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118381
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/943/083/7/1209430837.geojson
+++ b/data/120/943/083/7/1209430837.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.61023,47.6226,-122.61023,47.6226",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209430837,
-    "wof:lastmodified":1566623009,
+    "wof:lastmodified":1588726990,
     "wof:name":"Kariotis Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118467
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/943/459/9/1209434599.geojson
+++ b/data/120/943/459/9/1209434599.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.43054,47.10874,-122.43054,47.10874",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209434599,
-    "wof:lastmodified":1566623065,
+    "wof:lastmodified":1588726987,
     "wof:name":"Country Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118375
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/943/460/3/1209434603.geojson
+++ b/data/120/943/460/3/1209434603.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.3159,27.9946,-82.3159,27.9946",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209434603,
-    "wof:lastmodified":1566623057,
+    "wof:lastmodified":1588726990,
     "wof:name":"East Gate Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118469
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/943/461/9/1209434619.geojson
+++ b/data/120/943/461/9/1209434619.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.98595,29.12829,-80.98595,29.12829",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209434619,
-    "wof:lastmodified":1566623064,
+    "wof:lastmodified":1588726987,
     "wof:name":"Tanglewood Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118377
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/962/661/7/1209626617.geojson
+++ b/data/120/962/661/7/1209626617.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-84.59639,42.71056,-84.59639,42.71056",
@@ -30,7 +32,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -49,12 +51,14 @@
         }
     ],
     "wof:id":1209626617,
-    "wof:lastmodified":1566622014,
+    "wof:lastmodified":1588726988,
     "wof:name":"Riverview Estates Mobile Community",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118427
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/963/173/3/1209631733.geojson
+++ b/data/120/963/173/3/1209631733.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.1143,26.6323,-80.1143,26.6323",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209631733,
-    "wof:lastmodified":1566622071,
+    "wof:lastmodified":1588726989,
     "wof:name":"Green Acres Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118461
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/963/983/9/1209639839.geojson
+++ b/data/120/963/983/9/1209639839.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-123.13671,47.24567,-123.13671,47.24567",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
@@ -48,12 +50,14 @@
         }
     ],
     "wof:id":1209639839,
-    "wof:lastmodified":1566622071,
+    "wof:lastmodified":1588726989,
     "wof:name":"Evergreen Mobile Estates",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118465
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/973/134/9/1209731349.geojson
+++ b/data/120/973/134/9/1209731349.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.35529,41.33793,-122.35529,41.33793",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102081669
+        102081669,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1209731349,
-    "wof:lastmodified":1566622881,
+    "wof:lastmodified":1588726988,
     "wof:name":"Abrams Lake Mobile Estates",
     "wof:parent_id":102081669,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118423
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/973/509/5/1209735095.geojson
+++ b/data/120/973/509/5/1209735095.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.67548,38.80792,-76.67548,38.80792",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102083469
+        102083469,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7228536
     },
     "wof:country":"US",
-    "wof:geomhash":"a9e53a765ed23cd66f264751db7ebe89",
+    "wof:geomhash":"3912fa0cb722b3ee97e5837f460493e6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1209735095,
-    "wof:lastmodified":1566622924,
+    "wof:lastmodified":1588726988,
     "wof:name":"Boone's Mobile Estates",
     "wof:parent_id":102083469,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118425
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -76.67548000000002,
+    -76.67548,
     38.80792,
-    -76.67548000000002,
+    -76.67548,
     38.80792
 ],
-  "geometry": {"coordinates":[-76.67548000000002,38.80792],"type":"Point"}
+  "geometry": {"coordinates":[-76.67547999999999,38.80792],"type":"Point"}
 }

--- a/data/120/992/521/3/1209925213.geojson
+++ b/data/120/992/521/3/1209925213.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-92.06087,30.27509,-92.06087,30.27509",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102081919
+        102081919,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1209925213,
-    "wof:lastmodified":1566622528,
+    "wof:lastmodified":1588726987,
     "wof:name":"Country Pine Mobile Estates",
     "wof:parent_id":102081919,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118379
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/120/995/129/1/1209951291.geojson
+++ b/data/120/995/129/1/1209951291.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.18969,48.51669,-122.18969,48.51669",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102084225
+        102084225,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7714340
     },
     "wof:country":"US",
-    "wof:geomhash":"b06a096609a4317dd12a0c36fc9dac92",
+    "wof:geomhash":"14e9d70a17240dad8d21ef3278696cec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1209951291,
-    "wof:lastmodified":1566622518,
+    "wof:lastmodified":1588726987,
     "wof:name":"Cedar Lane Mobile Estates",
     "wof:parent_id":102084225,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118395
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -122.18968999999998,
+    -122.18969,
     48.51669,
-    -122.18968999999998,
+    -122.18969,
     48.51669
 ],
-  "geometry": {"coordinates":[-122.18968999999998,48.51669],"type":"Point"}
+  "geometry": {"coordinates":[-122.18969,48.51669],"type":"Point"}
 }

--- a/data/122/586/118/9/1225861189.geojson
+++ b/data/122/586/118/9/1225861189.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-111.58185,33.41901,-111.58185,33.41901",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102087421
+        102087421,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1225861189,
-    "wof:lastmodified":1566642298,
+    "wof:lastmodified":1588726980,
     "wof:name":"El Dorado Mobile Estates Resort",
     "wof:parent_id":102087421,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118177
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/595/518/1/1225955181.geojson
+++ b/data/122/595/518/1/1225955181.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-86.29639,42.18556,-86.29639,42.18556",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506991,
         85633793,
-        102083151
+        102083151,
+        404506991,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1225955181,
-    "wof:lastmodified":1566641816,
+    "wof:lastmodified":1588726986,
     "wof:name":"Hillview Mobile Estates",
     "wof:parent_id":404506991,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118371
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/605/870/3/1226058703.geojson
+++ b/data/122/605/870/3/1226058703.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-117.05781,33.2342,-117.05781,33.2342",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102083569
+        102083569,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1226058703,
-    "wof:lastmodified":1566642058,
+    "wof:lastmodified":1588726985,
     "wof:name":"Hideaway Mobile Estates",
     "wof:parent_id":102083569,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118319
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/606/234/5/1226062345.geojson
+++ b/data/122/606/234/5/1226062345.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-99.9683,37.74097,-99.9683,37.74097",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404503629,
         85633793,
-        102082141
+        102082141,
+        404503629,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1226062345,
-    "wof:lastmodified":1566642851,
+    "wof:lastmodified":1588726985,
     "wof:name":"Ranchwood Mobile Estates",
     "wof:parent_id":404503629,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118323
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/616/709/5/1226167095.geojson
+++ b/data/122/616/709/5/1226167095.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-110.90657,32.26252,-110.90657,32.26252",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102081135
+        102081135,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1226167095,
-    "wof:lastmodified":1566641966,
+    "wof:lastmodified":1588726984,
     "wof:name":"Paradise Village Mobile Estates",
     "wof:parent_id":102081135,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118291
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/616/866/3/1226168663.geojson
+++ b/data/122/616/866/3/1226168663.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-93.12584,30.21144,-93.12584,30.21144",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102081035
+        102081035,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1226168663,
-    "wof:lastmodified":1566641979,
+    "wof:lastmodified":1588726984,
     "wof:name":"Chardele Mobile Estates",
     "wof:parent_id":102081035,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118289
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/626/230/7/1226262307.geojson
+++ b/data/122/626/230/7/1226262307.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-86.15056,43.2125,-86.15056,43.2125",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507977,
         85633793,
-        102083707
+        102083707,
+        404507977,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1226262307,
-    "wof:lastmodified":1566641902,
+    "wof:lastmodified":1588726984,
     "wof:name":"Arlington Estates Mobile Village",
     "wof:parent_id":404507977,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118295
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/626/251/5/1226262515.geojson
+++ b/data/122/626/251/5/1226262515.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-86.20694,41.82361,-86.20694,41.82361",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507089,
         85633793,
-        102083027
+        102083027,
+        404507089,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1226262515,
-    "wof:lastmodified":1566641872,
+    "wof:lastmodified":1588726984,
     "wof:name":"Niles Pines Mobile Estates",
     "wof:parent_id":404507089,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118297
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/645/337/1/1226453371.geojson
+++ b/data/122/645/337/1/1226453371.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.63436,47.61089,-122.63436,47.61089",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102081243
+        102081243,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7714027
     },
     "wof:country":"US",
-    "wof:geomhash":"b854e915d6317ca3ee261936daa35a2f",
+    "wof:geomhash":"87508569431356d511effaa663cd0622",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1226453371,
-    "wof:lastmodified":1566641911,
+    "wof:lastmodified":1588726981,
     "wof:name":"Camelot Mobile Estates",
     "wof:parent_id":102081243,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118181
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -122.63436000000002,
-    47.61089000000001,
-    -122.63436000000002,
-    47.61089000000001
+    -122.63436,
+    47.61089,
+    -122.63436,
+    47.61089
 ],
-  "geometry": {"coordinates":[-122.63436000000002,47.61089000000001],"type":"Point"}
+  "geometry": {"coordinates":[-122.63436,47.61089],"type":"Point"}
 }

--- a/data/122/645/824/3/1226458243.geojson
+++ b/data/122/645/824/3/1226458243.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.77583,41.75083,-80.77583,41.75083",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404524713,
         85633793,
-        102083657
+        102083657,
+        404524713,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1226458243,
-    "wof:lastmodified":1566641942,
+    "wof:lastmodified":1588726980,
     "wof:name":"Jefferson Mobile Estates",
     "wof:parent_id":404524713,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118179
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/655/081/3/1226550813.geojson
+++ b/data/122/655/081/3/1226550813.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.33694,40.71278,-122.33694,40.71278",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102083577
+        102083577,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7232377
     },
     "wof:country":"US",
-    "wof:geomhash":"bd3e221d5deb5c903af8342c740ffa4d",
+    "wof:geomhash":"0474fb74fa36d31ed38a05d238f30ed4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1226550813,
-    "wof:lastmodified":1566642794,
+    "wof:lastmodified":1588726987,
     "wof:name":"Redding Lakeside Mobile Estates",
     "wof:parent_id":102083577,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118373
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -122.33693999999998,
+    -122.33694,
     40.71278,
-    -122.33693999999998,
+    -122.33694,
     40.71278
 ],
-  "geometry": {"coordinates":[-122.33693999999998,40.71278],"type":"Point"}
+  "geometry": {"coordinates":[-122.33694,40.71278],"type":"Point"}
 }

--- a/data/122/655/557/3/1226555573.geojson
+++ b/data/122/655/557/3/1226555573.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.2825,41.69639,-81.2825,41.69639",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404526955,
         85633793,
-        102083703
+        102083703,
+        404526955,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1226555573,
-    "wof:lastmodified":1566642750,
+    "wof:lastmodified":1588726986,
     "wof:name":"Avenues Mobile Estates",
     "wof:parent_id":404526955,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118369
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/656/502/1/1226565021.geojson
+++ b/data/122/656/502/1/1226565021.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-87.42222,46.28056,-87.42222,46.28056",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404508607,
         85633793,
-        102083039
+        102083039,
+        404508607,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1226565021,
-    "wof:lastmodified":1566642076,
+    "wof:lastmodified":1588726981,
     "wof:name":"Northernair Mobile Estates",
     "wof:parent_id":404508607,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118183
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/122/676/340/7/1226763407.geojson
+++ b/data/122/676/340/7/1226763407.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-114.53468,33.6078,-114.53468,33.6078",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102086221
+        102086221,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1226763407,
-    "wof:lastmodified":1566642548,
+    "wof:lastmodified":1588726985,
     "wof:name":"Blythe Marina Mobile Estates",
     "wof:parent_id":102086221,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118321
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/258/856/1/1242588561.geojson
+++ b/data/124/258/856/1/1242588561.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-92.81827,30.53195,-92.81827,30.53195",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102086679
+        102086679,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1242588561,
-    "wof:lastmodified":1566640135,
+    "wof:lastmodified":1588726983,
     "wof:name":"Grandview Mobile Estates",
     "wof:parent_id":102086679,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118269
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/258/898/9/1242588989.geojson
+++ b/data/124/258/898/9/1242588989.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.35283,47.02186,-122.35283,47.02186",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087547
+        102087547,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1242588989,
-    "wof:lastmodified":1566640141,
+    "wof:lastmodified":1588726983,
     "wof:name":"Parklane Mobile Estates",
     "wof:parent_id":102087547,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118267
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/269/384/1/1242693841.geojson
+++ b/data/124/269/384/1/1242693841.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-92.08949,30.23689,-92.08949,30.23689",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102081919
+        102081919,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1242693841,
-    "wof:lastmodified":1566640172,
+    "wof:lastmodified":1588726983,
     "wof:name":"Shorts Mobile Estates",
     "wof:parent_id":102081919,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118265
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/279/408/9/1242794089.geojson
+++ b/data/124/279/408/9/1242794089.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-111.09523,45.71937,-111.09523,45.71937",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688617,
-        102085133
+        102085133,
+        85688617
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1242794089,
-    "wof:lastmodified":1566640533,
+    "wof:lastmodified":1588726984,
     "wof:name":"Hidden Valley Mobile Estates",
     "wof:parent_id":102085133,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118283
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/289/322/1/1242893221.geojson
+++ b/data/124/289/322/1/1242893221.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.80554,27.71153,-81.80554,27.71153",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085843
+        102085843,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7190499
     },
     "wof:country":"US",
-    "wof:geomhash":"cad7022725339855ad2c2a1ced3c4265",
+    "wof:geomhash":"6587ada67ab5a0114e0728f3009db614",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1242893221,
-    "wof:lastmodified":1566639911,
+    "wof:lastmodified":1588726980,
     "wof:name":"Hammock Lake Mobile Estates",
     "wof:parent_id":102085843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118159
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -81.80554000000002,
+    -81.80554,
     27.71153,
-    -81.80554000000002,
+    -81.80554,
     27.71153
 ],
-  "geometry": {"coordinates":[-81.80554000000002,27.71153],"type":"Point"}
+  "geometry": {"coordinates":[-81.80553999999999,27.71153],"type":"Point"}
 }

--- a/data/124/289/330/7/1242893307.geojson
+++ b/data/124/289/330/7/1242893307.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.47856,38.2579,-76.47856,38.2579",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102082729
+        102082729,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1242893307,
-    "wof:lastmodified":1566639879,
+    "wof:lastmodified":1588726980,
     "wof:name":"Suburban Mobile Estates",
     "wof:parent_id":102082729,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118157
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/298/175/7/1242981757.geojson
+++ b/data/124/298/175/7/1242981757.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-85.63778,42.47222,-85.63778,42.47222",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506667,
         85633793,
-        102083043
+        102083043,
+        404506667,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1242981757,
-    "wof:lastmodified":1566640642,
+    "wof:lastmodified":1588726983,
     "wof:name":"Gun River Mobile Estates",
     "wof:parent_id":404506667,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118259
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/298/713/5/1242987135.geojson
+++ b/data/124/298/713/5/1242987135.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-73.87056,41.97861,-73.87056,41.97861",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522311,
         85633793,
-        102082363
+        102082363,
+        404522311,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1242987135,
-    "wof:lastmodified":1566640638,
+    "wof:lastmodified":1588726984,
     "wof:name":"Mountain View Mobile Estates",
     "wof:parent_id":404522311,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118279
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/299/571/3/1242995713.geojson
+++ b/data/124/299/571/3/1242995713.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.69476,38.81574,-76.69476,38.81574",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
         "Patuxent Mobile Estates"
@@ -41,15 +43,15 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102083469
+        102083469,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":4365061
     },
     "wof:country":"US",
-    "wof:geomhash":"cd2aae27a7740225e7fb24d7dec6de72",
+    "wof:geomhash":"964c8b896246adc3e35da014bb391182",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -60,20 +62,22 @@
         }
     ],
     "wof:id":1242995713,
-    "wof:lastmodified":1566640734,
+    "wof:lastmodified":1588726983,
     "wof:name":"Patuxent Mobile Estates",
     "wof:parent_id":102083469,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118271
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
     -76.69476,
-    38.81574000000001,
+    38.81574,
     -76.69476,
-    38.81574000000001
+    38.81574
 ],
-  "geometry": {"coordinates":[-76.69476,38.81574000000001],"type":"Point"}
+  "geometry": {"coordinates":[-76.69476,38.81574],"type":"Point"}
 }

--- a/data/124/309/192/9/1243091929.geojson
+++ b/data/124/309/192/9/1243091929.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.79432,36.78335,-76.79432,36.78335",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688747,
-        102086709
+        102086709,
+        85688747
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243091929,
-    "wof:lastmodified":1566639688,
+    "wof:lastmodified":1588726979,
     "wof:name":"Oaks Mobile Estates",
     "wof:parent_id":102086709,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118145
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/319/197/9/1243191979.geojson
+++ b/data/124/319/197/9/1243191979.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-112.16182,33.53615,-112.16182,33.53615",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102087421
+        102087421,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243191979,
-    "wof:lastmodified":1566640957,
+    "wof:lastmodified":1588726983,
     "wof:name":"Blue Sky Mobile Estates",
     "wof:parent_id":102087421,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118273
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/327/969/5/1243279695.geojson
+++ b/data/124/327/969/5/1243279695.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-92.06414,30.26638,-92.06414,30.26638",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102081919
+        102081919,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243279695,
-    "wof:lastmodified":1566640820,
+    "wof:lastmodified":1588726983,
     "wof:name":"Cypress Mobile Estates",
     "wof:parent_id":102081919,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118261
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/337/927/1/1243379271.geojson
+++ b/data/124/337/927/1/1243379271.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.9797,29.1159,-80.9797,29.1159",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085865
+        102085865,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243379271,
-    "wof:lastmodified":1566639756,
+    "wof:lastmodified":1588726983,
     "wof:name":"Briarwood Mobile Estates",
     "wof:parent_id":102085865,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118263
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/338/277/7/1243382777.geojson
+++ b/data/124/338/277/7/1243382777.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.4489,27.4658,-81.4489,27.4658",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085801
+        102085801,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243382777,
-    "wof:lastmodified":1566639656,
+    "wof:lastmodified":1588726984,
     "wof:name":"Jackson Creek Mobile Estates",
     "wof:parent_id":102085801,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118281
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/346/563/9/1243465639.geojson
+++ b/data/124/346/563/9/1243465639.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.39548,28.48511,-81.39548,28.48511",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085847
+        102085847,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243465639,
-    "wof:lastmodified":1566640231,
+    "wof:lastmodified":1588726984,
     "wof:name":"Wheel Estates Mobile Manor",
     "wof:parent_id":102085847,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118287
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/347/079/1/1243470791.geojson
+++ b/data/124/347/079/1/1243470791.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-111.58347,33.42088,-111.58347,33.42088",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102087421
+        102087421,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243470791,
-    "wof:lastmodified":1566640269,
+    "wof:lastmodified":1588726984,
     "wof:name":"Coral Sands Mobile Estates",
     "wof:parent_id":102087421,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118285
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/348/028/3/1243480283.geojson
+++ b/data/124/348/028/3/1243480283.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-92.08708,30.24428,-92.08708,30.24428",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102081919
+        102081919,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243480283,
-    "wof:lastmodified":1566640249,
+    "wof:lastmodified":1588726980,
     "wof:name":"Landall Mobile Estates",
     "wof:parent_id":102081919,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118155
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/356/573/3/1243565733.geojson
+++ b/data/124/356/573/3/1243565733.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.67691,38.80706,-76.67691,38.80706",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102083469
+        102083469,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":4349105
     },
     "wof:country":"US",
-    "wof:geomhash":"fa619451c778e46aac92672e2ccd3760",
+    "wof:geomhash":"943557c06cf3b68a7929b2ebeecc4579",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1243565733,
-    "wof:lastmodified":1566640457,
+    "wof:lastmodified":1588726983,
     "wof:name":"Boones Mobile Estates",
     "wof:parent_id":102083469,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118277
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -76.67690999999998,
+    -76.67691,
     38.80706,
-    -76.67690999999998,
+    -76.67691,
     38.80706
 ],
-  "geometry": {"coordinates":[-76.67690999999998,38.80706],"type":"Point"}
+  "geometry": {"coordinates":[-76.67691000000001,38.80706],"type":"Point"}
 }

--- a/data/124/357/002/9/1243570029.geojson
+++ b/data/124/357/002/9/1243570029.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-91.55794,40.96364,-91.55794,40.96364",
@@ -30,21 +32,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688713,
-        102086629
+        102086629,
+        85688713
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":4882447
     },
     "wof:country":"US",
-    "wof:geomhash":"34a19d86eb466d0f0cd3e2dfe528cb1b",
+    "wof:geomhash":"f7581a8f0541d4db73e7e940ae390ece",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -55,20 +57,22 @@
         }
     ],
     "wof:id":1243570029,
-    "wof:lastmodified":1566640431,
+    "wof:lastmodified":1588726980,
     "wof:name":"Woodside Mobile Estates",
     "wof:parent_id":102086629,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118161
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
     -91.55794,
-    40.96364000000001,
+    40.96364,
     -91.55794,
-    40.96364000000001
+    40.96364
 ],
-  "geometry": {"coordinates":[-91.55794,40.96364000000001],"type":"Point"}
+  "geometry": {"coordinates":[-91.55794,40.96364],"type":"Point"}
 }

--- a/data/124/357/019/1/1243570191.geojson
+++ b/data/124/357/019/1/1243570191.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.21264,26.00474,-80.21264,26.00474",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102084727
+        102084727,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7190763
     },
     "wof:country":"US",
-    "wof:geomhash":"b4a3c35fbdcab78427afcc7e6f8351cd",
+    "wof:geomhash":"a890d54e60a1285769d4d5463544a495",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1243570191,
-    "wof:lastmodified":1566640419,
+    "wof:lastmodified":1588726980,
     "wof:name":"New England Mobile Estates",
     "wof:parent_id":102084727,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118153
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -80.21264000000002,
+    -80.21264,
     26.00474,
-    -80.21264000000002,
+    -80.21264,
     26.00474
 ],
-  "geometry": {"coordinates":[-80.21264000000002,26.00474],"type":"Point"}
+  "geometry": {"coordinates":[-80.21263999999999,26.00474],"type":"Point"}
 }

--- a/data/124/357/406/5/1243574065.geojson
+++ b/data/124/357/406/5/1243574065.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.2883,27.9684,-82.2883,27.9684",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085773
+        102085773,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1243574065,
-    "wof:lastmodified":1566640372,
+    "wof:lastmodified":1588726980,
     "wof:name":"Brandon Mobile Estates",
     "wof:parent_id":102085773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118147
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/949/965/5/1259499655.geojson
+++ b/data/125/949/965/5/1259499655.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-87.02713,37.79039,-87.02713,37.79039",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688641,
-        102085691
+        102085691,
+        85688641
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1259499655,
-    "wof:lastmodified":1566641361,
+    "wof:lastmodified":1588726988,
     "wof:name":"Colonial Mobile Estates",
     "wof:parent_id":102085691,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118403
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/950/316/9/1259503169.geojson
+++ b/data/125/950/316/9/1259503169.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-85.82306,42.51806,-85.82306,42.51806",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506771,
         85633793,
-        102083043
+        102083043,
+        404506771,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1259503169,
-    "wof:lastmodified":1566641469,
+    "wof:lastmodified":1588726988,
     "wof:name":"Allegan Mobile Estates",
     "wof:parent_id":404506771,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118409
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/950/798/5/1259507985.geojson
+++ b/data/125/950/798/5/1259507985.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-96.87864,37.76718,-96.87864,37.76718",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404503819,
         85633793,
-        102082695
+        102082695,
+        404503819,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1259507985,
-    "wof:lastmodified":1566641426,
+    "wof:lastmodified":1588726988,
     "wof:name":"El Dorado Mobile Estates",
     "wof:parent_id":404503819,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118407
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/959/449/1/1259594491.geojson
+++ b/data/125/959/449/1/1259594491.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.57,39.71278,-82.57,39.71278",
@@ -29,15 +31,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404524579,
         85633793,
-        102083747
+        102083747,
+        404524579,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,12 +58,14 @@
         }
     ],
     "wof:id":1259594491,
-    "wof:lastmodified":1566641491,
+    "wof:lastmodified":1588726988,
     "wof:name":"Lancaster Mobile Estates",
     "wof:parent_id":404524579,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118415
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/960/875/9/1259608759.geojson
+++ b/data/125/960/875/9/1259608759.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-73.68376,43.30441,-73.68376,43.30441",
@@ -30,22 +32,22 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404523293,
         85633793,
-        102081791
+        102081791,
+        404523293,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7707078
     },
     "wof:country":"US",
-    "wof:geomhash":"199b5d4221fef9a77c922f82bce2855c",
+    "wof:geomhash":"631fd7c8a02605f4708fc92644739cf8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -57,20 +59,22 @@
         }
     ],
     "wof:id":1259608759,
-    "wof:lastmodified":1566641548,
+    "wof:lastmodified":1588726989,
     "wof:name":"Northwinds Mobile Estates",
     "wof:parent_id":404523293,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118457
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -73.68375999999998,
+    -73.68376,
     43.30441,
-    -73.68375999999998,
+    -73.68376,
     43.30441
 ],
-  "geometry": {"coordinates":[-73.68375999999998,43.30441],"type":"Point"}
+  "geometry": {"coordinates":[-73.68376000000001,43.30441],"type":"Point"}
 }

--- a/data/125/961/782/1/1259617821.geojson
+++ b/data/125/961/782/1/1259617821.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-119.28039,34.43555,-119.28039,34.43555",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102086933
+        102086933,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1259617821,
-    "wof:lastmodified":1566641480,
+    "wof:lastmodified":1588726987,
     "wof:name":"Del Francia Mobile Estates",
     "wof:parent_id":102086933,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118399
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/970/828/1/1259708281.geojson
+++ b/data/125/970/828/1/1259708281.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.36083,47.17268,-122.36083,47.17268",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087547
+        102087547,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1259708281,
-    "wof:lastmodified":1566641163,
+    "wof:lastmodified":1588726988,
     "wof:name":"Canyon Terrace Mobile Estates",
     "wof:parent_id":102087547,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118433
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/971/780/3/1259717803.geojson
+++ b/data/125/971/780/3/1259717803.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-106.13248,31.66706,-106.13248,31.66706",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
         "Cochran Mobile Park Colonia"
@@ -41,8 +43,8 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688753,
-        102085989
+        102085989,
+        85688753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -60,12 +62,14 @@
         }
     ],
     "wof:id":1259717803,
-    "wof:lastmodified":1566641355,
+    "wof:lastmodified":1588726989,
     "wof:name":"Cochran Mobile Park Colonia",
     "wof:parent_id":102085989,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118459
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/979/991/5/1259799915.geojson
+++ b/data/125/979/991/5/1259799915.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-85.3826,31.18889,-85.3826,31.18889",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688675,
-        102085441
+        102085441,
+        85688675
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1259799915,
-    "wof:lastmodified":1566641224,
+    "wof:lastmodified":1588726988,
     "wof:name":"Grand Villa Mobile Estates",
     "wof:parent_id":102085441,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118413
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/980/809/7/1259808097.geojson
+++ b/data/125/980/809/7/1259808097.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-123.16038,48.07916,-123.16038,48.07916",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102084229
+        102084229,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1259808097,
-    "wof:lastmodified":1566641706,
+    "wof:lastmodified":1588726987,
     "wof:name":"Green Acres Mobile Estates",
     "wof:parent_id":102084229,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118397
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/982/031/7/1259820317.geojson
+++ b/data/125/982/031/7/1259820317.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.37972,41.40389,-122.37972,41.40389",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102081669
+        102081669,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1259820317,
-    "wof:lastmodified":1566641418,
+    "wof:lastmodified":1588726988,
     "wof:name":"Cal-ore Trail Mobile Estates",
     "wof:parent_id":102081669,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118411
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/989/607/1/1259896071.geojson
+++ b/data/125/989/607/1/1259896071.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.64546,47.62415,-122.64546,47.62415",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102081243
+        102081243,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1259896071,
-    "wof:lastmodified":1566641781,
+    "wof:lastmodified":1588726988,
     "wof:name":"Silverdale Mobile Estates",
     "wof:parent_id":102081243,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118417
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/125/991/649/9/1259916499.geojson
+++ b/data/125/991/649/9/1259916499.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-86.52083,42.00806,-86.52083,42.00806",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506997,
         85633793,
-        102083151
+        102083151,
+        404506997,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1259916499,
-    "wof:lastmodified":1566640985,
+    "wof:lastmodified":1588726988,
     "wof:name":"Lakeshore Mobile Estates Park",
     "wof:parent_id":404506997,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118421
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/126/011/598/9/1260115989.geojson
+++ b/data/126/011/598/9/1260115989.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.4004,47.15285,-122.4004,47.15285",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087547
+        102087547,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1260115989,
-    "wof:lastmodified":1566623743,
+    "wof:lastmodified":1588726981,
     "wof:name":"Franklin Pierce Mobile Estates",
     "wof:parent_id":102087547,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118195
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/126/020/291/7/1260202917.geojson
+++ b/data/126/020/291/7/1260202917.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-87.61056,45.12972,-87.61056,45.12972",
@@ -30,22 +32,22 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404508819,
         85633793,
-        102083089
+        102083089,
+        404508819,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7149850
     },
     "wof:country":"US",
-    "wof:geomhash":"fae3c18f0b8530b13db3bc3a42996f65",
+    "wof:geomhash":"015c6642a2ee07ed715184ad11e83425",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -57,20 +59,22 @@
         }
     ],
     "wof:id":1260202917,
-    "wof:lastmodified":1566623729,
+    "wof:lastmodified":1588726981,
     "wof:name":"Bayside Mobile Estates",
     "wof:parent_id":404508819,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118189
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -87.61055999999998,
+    -87.61056,
     45.12972,
-    -87.61055999999998,
+    -87.61056,
     45.12972
 ],
-  "geometry": {"coordinates":[-87.61055999999998,45.12972],"type":"Point"}
+  "geometry": {"coordinates":[-87.61056000000001,45.12972],"type":"Point"}
 }

--- a/data/126/030/133/3/1260301333.geojson
+++ b/data/126/030/133/3/1260301333.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-110.95421,32.15693,-110.95421,32.15693",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102081135
+        102081135,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1260301333,
-    "wof:lastmodified":1566623626,
+    "wof:lastmodified":1588726981,
     "wof:name":"Parklane Mobile Estates",
     "wof:parent_id":102081135,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118191
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/126/030/140/7/1260301407.geojson
+++ b/data/126/030/140/7/1260301407.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-77.9328,35.3614,-77.9328,35.3614",
@@ -30,14 +32,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688773,
-        102087601
+        102087601,
+        85688773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,12 +57,14 @@
         }
     ],
     "wof:id":1260301407,
-    "wof:lastmodified":1566623675,
+    "wof:lastmodified":1588726981,
     "wof:name":"Woodshire Mobile Estates",
     "wof:parent_id":102087601,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118193
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/613/921/7/1276139217.geojson
+++ b/data/127/613/921/7/1276139217.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-73.88806,43.14528,-73.88806,43.14528",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404523169,
         85633793,
-        102082413
+        102082413,
+        404523169,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1276139217,
-    "wof:lastmodified":1566621414,
+    "wof:lastmodified":1588726986,
     "wof:name":"Della Mobile Estates",
     "wof:parent_id":404523169,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118367
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/615/807/3/1276158073.geojson
+++ b/data/127/615/807/3/1276158073.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.49969,48.78697,-122.49969,48.78697",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102085363
+        102085363,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276158073,
-    "wof:lastmodified":1566621618,
+    "wof:lastmodified":1588726986,
     "wof:name":"Bakerview Mobile Estates",
     "wof:parent_id":102085363,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118349
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/623/922/1/1276239221.geojson
+++ b/data/127/623/922/1/1276239221.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-92.14689,30.12494,-92.14689,30.12494",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102081919
+        102081919,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276239221,
-    "wof:lastmodified":1566621522,
+    "wof:lastmodified":1588726986,
     "wof:name":"Going West Mobile Estates",
     "wof:parent_id":102081919,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118345
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/625/371/3/1276253713.geojson
+++ b/data/127/625/371/3/1276253713.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.99092,29.11937,-80.99092,29.11937",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085865
+        102085865,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7192801
     },
     "wof:country":"US",
-    "wof:geomhash":"935bc080a5dadf23cd99203128a2b30c",
+    "wof:geomhash":"70a8f2ae428be04c67477681ef416eb4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1276253713,
-    "wof:lastmodified":1566621432,
+    "wof:lastmodified":1588726985,
     "wof:name":"Maplewood Mobile Estates",
     "wof:parent_id":102085865,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118317
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -80.99091999999997,
+    -80.99092,
     29.11937,
-    -80.99091999999997,
+    -80.99092,
     29.11937
 ],
-  "geometry": {"coordinates":[-80.99091999999997,29.11937],"type":"Point"}
+  "geometry": {"coordinates":[-80.99092,29.11937],"type":"Point"}
 }

--- a/data/127/635/564/5/1276355645.geojson
+++ b/data/127/635/564/5/1276355645.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.7819,32.4149,-81.7819,32.4149",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688535,
-        102084405
+        102084405,
+        85688535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276355645,
-    "wof:lastmodified":1566621205,
+    "wof:lastmodified":1588726984,
     "wof:name":"Woodland Mobile Estates",
     "wof:parent_id":102084405,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118305
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/635/578/5/1276355785.geojson
+++ b/data/127/635/578/5/1276355785.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-78.1397,35.5804,-78.1397,35.5804",
@@ -30,14 +32,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688773,
-        102080883
+        102080883,
+        85688773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,12 +57,14 @@
         }
     ],
     "wof:id":1276355785,
-    "wof:lastmodified":1566621234,
+    "wof:lastmodified":1588726984,
     "wof:name":"Country Squire Mobile Estates",
     "wof:parent_id":102080883,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118307
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/635/603/1/1276356031.geojson
+++ b/data/127/635/603/1/1276356031.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-92.1925,46.825,-92.1925,46.825",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404513281,
         85633793,
-        102087653
+        102087653,
+        404513281,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1276356031,
-    "wof:lastmodified":1566621184,
+    "wof:lastmodified":1588726985,
     "wof:name":"Birchwood Mobile Estates",
     "wof:parent_id":404513281,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118313
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/635/894/5/1276358945.geojson
+++ b/data/127/635/894/5/1276358945.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.40639,40.98667,-81.40639,40.98667",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404525793,
         85633793,
-        102083731
+        102083731,
+        404525793,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1276358945,
-    "wof:lastmodified":1566621185,
+    "wof:lastmodified":1588726985,
     "wof:name":"Maces Mobile Estates",
     "wof:parent_id":404525793,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118315
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/647/925/7/1276479257.geojson
+++ b/data/127/647/925/7/1276479257.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.22505,47.40469,-122.22505,47.40469",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102086191
+        102086191,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276479257,
-    "wof:lastmodified":1566621456,
+    "wof:lastmodified":1588726985,
     "wof:name":"Willo Vista Mobile Estates",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118309
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/656/856/5/1276568565.geojson
+++ b/data/127/656/856/5/1276568565.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.7841,34.7004,-76.7841,34.7004",
@@ -30,14 +32,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688773,
-        102080875
+        102080875,
+        85688773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,12 +57,14 @@
         }
     ],
     "wof:id":1276568565,
-    "wof:lastmodified":1566621039,
+    "wof:lastmodified":1588726984,
     "wof:name":"Coastal Mobile Estates",
     "wof:parent_id":102080875,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118299
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/657/398/5/1276573985.geojson
+++ b/data/127/657/398/5/1276573985.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-88.91278,30.44228,-88.91278,30.44228",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688579,
-        102087223
+        102087223,
+        85688579
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276573985,
-    "wof:lastmodified":1566621291,
+    "wof:lastmodified":1588726986,
     "wof:name":"Rolling Heights Mobile Estates",
     "wof:parent_id":102087223,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118353
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/658/926/1/1276589261.geojson
+++ b/data/127/658/926/1/1276589261.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.29005,47.16505,-122.29005,47.16505",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087547
+        102087547,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276589261,
-    "wof:lastmodified":1566621091,
+    "wof:lastmodified":1588726984,
     "wof:name":"Meridian Mobile Estates",
     "wof:parent_id":102087547,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118301
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/669/393/5/1276693935.geojson
+++ b/data/127/669/393/5/1276693935.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-112.31627,33.46254,-112.31627,33.46254",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102087421
+        102087421,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276693935,
-    "wof:lastmodified":1566621010,
+    "wof:lastmodified":1588726986,
     "wof:name":"Country Hills Mobile Estates",
     "wof:parent_id":102087421,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118351
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/678/308/9/1276783089.geojson
+++ b/data/127/678/308/9/1276783089.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.62664,39.21556,-76.62664,39.21556",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102083469
+        102083469,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7228942
     },
     "wof:country":"US",
-    "wof:geomhash":"d1d5a26febecbb2e507ed1fd65b8fd60",
+    "wof:geomhash":"f2480f06c21963809089641bb43e4a4c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1276783089,
-    "wof:lastmodified":1566621464,
+    "wof:lastmodified":1588726985,
     "wof:name":"Terrace View Mobile Estates",
     "wof:parent_id":102083469,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118339
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -76.62664000000002,
+    -76.62664,
     39.21556,
-    -76.62664000000002,
+    -76.62664,
     39.21556
 ],
-  "geometry": {"coordinates":[-76.62664000000002,39.21556],"type":"Point"}
+  "geometry": {"coordinates":[-76.62663999999999,39.21556],"type":"Point"}
 }

--- a/data/127/679/083/5/1276790835.geojson
+++ b/data/127/679/083/5/1276790835.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-88.47714,30.41082,-88.47714,30.41082",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688579,
-        102083161
+        102083161,
+        85688579
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276790835,
-    "wof:lastmodified":1566621696,
+    "wof:lastmodified":1588726986,
     "wof:name":"East Lawn Mobile Estates",
     "wof:parent_id":102083161,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118343
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/688/942/3/1276889423.geojson
+++ b/data/127/688/942/3/1276889423.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-90.32333,32.32194,-90.32333,32.32194",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688579,
-        102081407
+        102081407,
+        85688579
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276889423,
-    "wof:lastmodified":1566620867,
+    "wof:lastmodified":1588726984,
     "wof:name":"Springridge Mobile Estates",
     "wof:parent_id":102081407,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118303
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/699/729/5/1276997295.geojson
+++ b/data/127/699/729/5/1276997295.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.3136,27.9948,-82.3136,27.9948",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085773
+        102085773,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1276997295,
-    "wof:lastmodified":1566621826,
+    "wof:lastmodified":1588726986,
     "wof:name":"Hillcrest Mobile Estates",
     "wof:parent_id":102085773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118357
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/700/173/3/1277001733.geojson
+++ b/data/127/700/173/3/1277001733.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-85.34738,31.28842,-85.34738,31.28842",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688675,
-        102085441
+        102085441,
+        85688675
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1277001733,
-    "wof:lastmodified":1566620798,
+    "wof:lastmodified":1588726986,
     "wof:name":"Pointe South Mobile Estates",
     "wof:parent_id":102085441,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118363
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/700/625/7/1277006257.geojson
+++ b/data/127/700/625/7/1277006257.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-88.91589,30.4418,-88.91589,30.4418",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688579,
-        102087223
+        102087223,
+        85688579
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1277006257,
-    "wof:lastmodified":1566620818,
+    "wof:lastmodified":1588726986,
     "wof:name":"Rolling Hills Mobile Estates",
     "wof:parent_id":102087223,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118361
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/700/777/3/1277007773.geojson
+++ b/data/127/700/777/3/1277007773.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-85.40902,31.2604,-85.40902,31.2604",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688675,
-        102085441
+        102085441,
+        85688675
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1277007773,
-    "wof:lastmodified":1566620805,
+    "wof:lastmodified":1588726986,
     "wof:name":"La Vista Mobile Estates",
     "wof:parent_id":102085441,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118359
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/708/527/7/1277085277.geojson
+++ b/data/127/708/527/7/1277085277.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.21444,47.3395,-122.21444,47.3395",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102086191
+        102086191,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1277085277,
-    "wof:lastmodified":1566620692,
+    "wof:lastmodified":1588726986,
     "wof:name":"The River Mobile Estates",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118355
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/127/709/013/5/1277090135.geojson
+++ b/data/127/709/013/5/1277090135.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-77.34691,35.62711,-77.34691,35.62711",
@@ -30,21 +32,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688773,
-        102087595
+        102087595,
+        85688773
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":4490963
     },
     "wof:country":"US",
-    "wof:geomhash":"cc0ac28b8fa361c1eb0ef244deb955cc",
+    "wof:geomhash":"2e293afa9b23da034a9d1333263392f8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -55,20 +57,22 @@
         }
     ],
     "wof:id":1277090135,
-    "wof:lastmodified":1566620717,
+    "wof:lastmodified":1588726985,
     "wof:name":"Shady Knoll Mobile Estates",
     "wof:parent_id":102087595,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118341
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
     -77.34691,
-    35.62710999999999,
+    35.62711,
     -77.34691,
-    35.62710999999999
+    35.62711
 ],
-  "geometry": {"coordinates":[-77.34690999999999,35.62710999999999],"type":"Point"}
+  "geometry": {"coordinates":[-77.34690999999999,35.62711],"type":"Point"}
 }

--- a/data/129/291/424/9/1292914249.geojson
+++ b/data/129/291/424/9/1292914249.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-121.08828,38.92601,-121.08828,38.92601",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:spa_x_preferred":[
         "Auburn Hills Mobile Estates"
@@ -38,8 +40,8 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102080863
+        102080863,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1292914249,
-    "wof:lastmodified":1566620330,
+    "wof:lastmodified":1588726982,
     "wof:name":"Auburn Hills Mobile Estates",
     "wof:parent_id":102080863,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118229
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/291/928/7/1292919287.geojson
+++ b/data/129/291/928/7/1292919287.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-83.36333,43.51194,-83.36333,43.51194",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404508035,
         85633793,
-        102082989
+        102082989,
+        404508035,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1292919287,
-    "wof:lastmodified":1566620364,
+    "wof:lastmodified":1588726982,
     "wof:name":"Pinerest Mobile Estates",
     "wof:parent_id":404508035,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118227
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/292/862/1/1292928621.geojson
+++ b/data/129/292/862/1/1292928621.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-85.63639,43.08833,-85.63639,43.08833",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507861,
         85633793,
-        102083023
+        102083023,
+        404507861,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1292928621,
-    "wof:lastmodified":1566619659,
+    "wof:lastmodified":1588726982,
     "wof:name":"Northern Estates Mobile Village South",
     "wof:parent_id":404507861,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118243
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/302/033/5/1293020335.geojson
+++ b/data/129/302/033/5/1293020335.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-83.40472,41.20222,-83.40472,41.20222",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404525609,
         85633793,
-        102084717
+        102084717,
+        404525609,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1293020335,
-    "wof:lastmodified":1566620310,
+    "wof:lastmodified":1588726983,
     "wof:name":"Fostoria Mobile Estates",
     "wof:parent_id":404525609,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118245
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/302/530/1/1293025301.geojson
+++ b/data/129/302/530/1/1293025301.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.1715,25.9788,-80.1715,25.9788",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102084727
+        102084727,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1293025301,
-    "wof:lastmodified":1566620291,
+    "wof:lastmodified":1588726983,
     "wof:name":"Holiday Mobile Estates",
     "wof:parent_id":102084727,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118251
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/311/493/9/1293114939.geojson
+++ b/data/129/311/493/9/1293114939.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-73.84889,43.10222,-73.84889,43.10222",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404523169,
         85633793,
-        102082413
+        102082413,
+        404523169,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1293114939,
-    "wof:lastmodified":1566620420,
+    "wof:lastmodified":1588726983,
     "wof:name":"Grange Road Mobile Estates",
     "wof:parent_id":404523169,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118249
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/311/830/3/1293118303.geojson
+++ b/data/129/311/830/3/1293118303.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.14343,48.17669,-122.14343,48.17669",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087537
+        102087537,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1293118303,
-    "wof:lastmodified":1566620426,
+    "wof:lastmodified":1588726983,
     "wof:name":"Mobile Estates",
     "wof:parent_id":102087537,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118247
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/330/861/1/1293308611.geojson
+++ b/data/129/330/861/1/1293308611.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.6525,40.98,-80.6525,40.98",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404526095,
         85633793,
-        102084799
+        102084799,
+        404526095,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1293308611,
-    "wof:lastmodified":1566619478,
+    "wof:lastmodified":1588726982,
     "wof:name":"Beechwood Mobile Estates",
     "wof:parent_id":404526095,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118217
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/332/965/3/1293329653.geojson
+++ b/data/129/332/965/3/1293329653.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-83.40556,43.48083,-83.40556,43.48083",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404508125,
         85633793,
-        102082989
+        102082989,
+        404508125,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1293329653,
-    "wof:lastmodified":1566620138,
+    "wof:lastmodified":1588726983,
     "wof:name":"Caro Mobile Estates",
     "wof:parent_id":404508125,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118253
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/341/419/7/1293414197.geojson
+++ b/data/129/341/419/7/1293414197.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.15512,48.10226,-122.15512,48.10226",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087537
+        102087537,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1293414197,
-    "wof:lastmodified":1566619735,
+    "wof:lastmodified":1588726981,
     "wof:name":"Country Mobile Estates",
     "wof:parent_id":102087537,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118211
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/350/352/1/1293503521.geojson
+++ b/data/129/350/352/1/1293503521.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.46258,48.74043,-122.46258,48.74043",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102085363
+        102085363,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1293503521,
-    "wof:lastmodified":1566620077,
+    "wof:lastmodified":1588726983,
     "wof:name":"Lakeway Mobile Estates",
     "wof:parent_id":102085363,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118255
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/352/599/3/1293525993.geojson
+++ b/data/129/352/599/3/1293525993.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.31225,47.05183,-122.31225,47.05183",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087547
+        102087547,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1293525993,
-    "wof:lastmodified":1566619553,
+    "wof:lastmodified":1588726982,
     "wof:name":"Shadow Pines Mobile Estates",
     "wof:parent_id":102087547,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118213
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/360/863/9/1293608639.geojson
+++ b/data/129/360/863/9/1293608639.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-83.825,42.56667,-83.825,42.56667",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404507289,
         85633793,
-        102083145
+        102083145,
+        404507289,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1293608639,
-    "wof:lastmodified":1566620251,
+    "wof:lastmodified":1588726982,
     "wof:name":"Sylvan Glen Mobile Estates",
     "wof:parent_id":404507289,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118241
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/369/803/7/1293698037.geojson
+++ b/data/129/369/803/7/1293698037.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.0544,32.0416,-81.0544,32.0416",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688535,
-        102082337
+        102082337,
+        85688535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1293698037,
-    "wof:lastmodified":1566620147,
+    "wof:lastmodified":1588726982,
     "wof:name":"Thunderbolt Mobile Estates",
     "wof:parent_id":102082337,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118233
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/371/177/5/1293711775.geojson
+++ b/data/129/371/177/5/1293711775.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.9652,28.1554,-81.9652,28.1554",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085843
+        102085843,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1293711775,
-    "wof:lastmodified":1566619881,
+    "wof:lastmodified":1588726982,
     "wof:name":"Kern Mobile Estates",
     "wof:parent_id":102085843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118219
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/379/954/7/1293799547.geojson
+++ b/data/129/379/954/7/1293799547.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.84,40.54389,-82.84,40.54389",
@@ -30,22 +32,22 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404527007,
         85633793,
-        102083749
+        102083749,
+        404527007,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7235129
     },
     "wof:country":"US",
-    "wof:geomhash":"466528ed857c74586bdf2325827465ff",
+    "wof:geomhash":"08942209094b29257a25fd799c449934",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -57,20 +59,22 @@
         }
     ],
     "wof:id":1293799547,
-    "wof:lastmodified":1566619682,
+    "wof:lastmodified":1588726982,
     "wof:name":"Mohawk Mobile Estates",
     "wof:parent_id":404527007,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118231
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
     -82.84,
-    40.54389000000001,
+    40.54389,
     -82.84,
-    40.54389000000001
+    40.54389
 ],
-  "geometry": {"coordinates":[-82.84,40.54389000000001],"type":"Point"}
+  "geometry": {"coordinates":[-82.84,40.54389],"type":"Point"}
 }

--- a/data/129/380/351/7/1293803517.geojson
+++ b/data/129/380/351/7/1293803517.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.5912,28.1423,-81.5912,28.1423",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085843
+        102085843,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1293803517,
-    "wof:lastmodified":1566620538,
+    "wof:lastmodified":1588726982,
     "wof:name":"Davenport Mobile Estates",
     "wof:parent_id":102085843,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118215
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/129/380/832/1/1293808321.geojson
+++ b/data/129/380/832/1/1293808321.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-95.37556,45.86111,-95.37556,45.86111",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404513751,
         85633793,
-        102087127
+        102087127,
+        404513751,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1293808321,
-    "wof:lastmodified":1566620516,
+    "wof:lastmodified":1588726982,
     "wof:name":"Mobile Park Estates",
     "wof:parent_id":404513751,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118225
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/973/158/7/1309731587.geojson
+++ b/data/130/973/158/7/1309731587.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.4454,27.4689,-81.4454,27.4689",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085801
+        102085801,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1309731587,
-    "wof:lastmodified":1566628228,
+    "wof:lastmodified":1588726979,
     "wof:name":"Francis I Mobile Estates",
     "wof:parent_id":102085801,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118137
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/973/179/9/1309731799.geojson
+++ b/data/130/973/179/9/1309731799.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.20334,47.81848,-122.20334,47.81848",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087537
+        102087537,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1309731799,
-    "wof:lastmodified":1566628279,
+    "wof:lastmodified":1588726979,
     "wof:name":"Kennard Mobile Estates",
     "wof:parent_id":102087537,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118139
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/981/978/9/1309819789.geojson
+++ b/data/130/981/978/9/1309819789.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-83.49583,43.03333,-83.49583,43.03333",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506591,
         85633793,
-        102083111
+        102083111,
+        404506591,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1309819789,
-    "wof:lastmodified":1566628310,
+    "wof:lastmodified":1588726985,
     "wof:name":"Davison East Mobile Estates",
     "wof:parent_id":404506591,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118325
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/982/350/9/1309823509.geojson
+++ b/data/130/982/350/9/1309823509.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.23872,47.75812,-122.23872,47.75812",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102086191
+        102086191,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1309823509,
-    "wof:lastmodified":1566628092,
+    "wof:lastmodified":1588726985,
     "wof:name":"Sarvis Mobile Estates",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118331
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/992/141/1/1309921411.geojson
+++ b/data/130/992/141/1/1309921411.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.47117,48.89326,-122.47117,48.89326",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102085363
+        102085363,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1309921411,
-    "wof:lastmodified":1566628176,
+    "wof:lastmodified":1588726979,
     "wof:name":"Royal Coachman Mobile Estates",
     "wof:parent_id":102085363,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118141
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/130/993/018/3/1309930183.geojson
+++ b/data/130/993/018/3/1309930183.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-70.82922,42.98176,-70.82922,42.98176",
@@ -30,22 +32,22 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688689,
         102191575,
-        404476771,
         85633793,
-        102086507
+        102086507,
+        404476771,
+        85688689
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":5092607
     },
     "wof:country":"US",
-    "wof:geomhash":"81807f1e97b3d2ed7973690e9b89293b",
+    "wof:geomhash":"c6f53d1e8791fdf76cca33fa9b9ea971",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -57,20 +59,22 @@
         }
     ],
     "wof:id":1309930183,
-    "wof:lastmodified":1566628202,
+    "wof:lastmodified":1588726979,
     "wof:name":"Shel Al Mobile Estates",
     "wof:parent_id":404476771,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118143
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -70.82921999999998,
+    -70.82922,
     42.98176,
-    -70.82921999999998,
+    -70.82922,
     42.98176
 ],
-  "geometry": {"coordinates":[-70.82921999999998,42.98176],"type":"Point"}
+  "geometry": {"coordinates":[-70.82922000000001,42.98176],"type":"Point"}
 }

--- a/data/130/994/047/5/1309940475.geojson
+++ b/data/130/994/047/5/1309940475.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.48504,48.71614,-122.48504,48.71614",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102085363
+        102085363,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7714002
     },
     "wof:country":"US",
-    "wof:geomhash":"708b43f449f01ebc78119626f7636f07",
+    "wof:geomhash":"cd5dcd556232244bae05f509dba79538",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1309940475,
-    "wof:lastmodified":1566628215,
+    "wof:lastmodified":1588726979,
     "wof:name":"South End Mobile Estates",
     "wof:parent_id":102085363,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118135
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -122.48503999999998,
+    -122.48504,
     48.71614,
-    -122.48503999999998,
+    -122.48504,
     48.71614
 ],
-  "geometry": {"coordinates":[-122.48503999999998,48.71614],"type":"Point"}
+  "geometry": {"coordinates":[-122.48504,48.71614],"type":"Point"}
 }

--- a/data/131/002/497/7/1310024977.geojson
+++ b/data/131/002/497/7/1310024977.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.83136,39.11844,-76.83136,39.11844",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102084263
+        102084263,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310024977,
-    "wof:lastmodified":1566624921,
+    "wof:lastmodified":1588726989,
     "wof:name":"Beech Crest Mobile Estates",
     "wof:parent_id":102084263,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118451
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/012/228/9/1310122289.geojson
+++ b/data/131/012/228/9/1310122289.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-95.37667,45.88861,-95.37667,45.88861",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404513751,
         85633793,
-        102087127
+        102087127,
+        404513751,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1310122289,
-    "wof:lastmodified":1566624213,
+    "wof:lastmodified":1588726989,
     "wof:name":"Alexandria Mobile Estates",
     "wof:parent_id":404513751,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118435
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/014/270/7/1310142707.geojson
+++ b/data/131/014/270/7/1310142707.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.27972,40.46528,-122.27972,40.46528",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102083577
+        102083577,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310142707,
-    "wof:lastmodified":1566624296,
+    "wof:lastmodified":1588726987,
     "wof:name":"River Park Mobile Estates",
     "wof:parent_id":102083577,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118393
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/022/143/3/1310221433.geojson
+++ b/data/131/022/143/3/1310221433.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.66719,38.76234,-76.66719,38.76234",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102083469
+        102083469,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310221433,
-    "wof:lastmodified":1566624330,
+    "wof:lastmodified":1588726989,
     "wof:name":"Lyons Creek Mobile Estates",
     "wof:parent_id":102083469,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118439
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/042/975/1/1310429751.geojson
+++ b/data/131/042/975/1/1310429751.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-88.948,30.44092,-88.948,30.44092",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688579,
-        102087223
+        102087223,
+        85688579
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310429751,
-    "wof:lastmodified":1566624659,
+    "wof:lastmodified":1588726987,
     "wof:name":"Imperial Mobile Estates",
     "wof:parent_id":102087223,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118391
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/044/209/9/1310442099.geojson
+++ b/data/131/044/209/9/1310442099.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.64972,41.71639,-122.64972,41.71639",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102081669
+        102081669,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310442099,
-    "wof:lastmodified":1566624680,
+    "wof:lastmodified":1588726987,
     "wof:name":"Oak Ridge Mobile Estates",
     "wof:parent_id":102081669,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118387
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/044/242/9/1310442429.geojson
+++ b/data/131/044/242/9/1310442429.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-114.62602,32.66478,-114.62602,32.66478",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102081527
+        102081527,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310442429,
-    "wof:lastmodified":1566624677,
+    "wof:lastmodified":1588726987,
     "wof:name":"Mesa Terrace Mobile Estates",
     "wof:parent_id":102081527,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118389
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/051/786/7/1310517867.geojson
+++ b/data/131/051/786/7/1310517867.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.65349,48.30122,-122.65349,48.30122",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087543
+        102087543,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310517867,
-    "wof:lastmodified":1566625011,
+    "wof:lastmodified":1588726987,
     "wof:name":"Western Village Mobile Estates",
     "wof:parent_id":102087543,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118385
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/052/082/3/1310520823.geojson
+++ b/data/131/052/082/3/1310520823.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.3208,27.9956,-82.3208,27.9956",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085773
+        102085773,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310520823,
-    "wof:lastmodified":1566624513,
+    "wof:lastmodified":1588726989,
     "wof:name":"Lake Marie Mobile Estates",
     "wof:parent_id":102085773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118445
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/061/659/3/1310616593.geojson
+++ b/data/131/061/659/3/1310616593.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-111.57601,35.2292,-111.57601,35.2292",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102086831
+        102086831,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310616593,
-    "wof:lastmodified":1566624862,
+    "wof:lastmodified":1588726989,
     "wof:name":"Colony Mobile Estates",
     "wof:parent_id":102086831,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118449
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/061/731/7/1310617317.geojson
+++ b/data/131/061/731/7/1310617317.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-114.62704,32.67747,-114.62704,32.67747",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102081527
+        102081527,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310617317,
-    "wof:lastmodified":1566624849,
+    "wof:lastmodified":1588726989,
     "wof:name":"Desert Palms Mobile Estates",
     "wof:parent_id":102081527,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118447
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/062/068/1/1310620681.geojson
+++ b/data/131/062/068/1/1310620681.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-123.12207,48.0812,-123.12207,48.0812",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102084229
+        102084229,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310620681,
-    "wof:lastmodified":1566624468,
+    "wof:lastmodified":1588726989,
     "wof:name":"Juniper Mobile Estates",
     "wof:parent_id":102084229,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118441
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/062/334/9/1310623349.geojson
+++ b/data/131/062/334/9/1310623349.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-77.1497,39.35955,-77.1497,39.35955",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102082717
+        102082717,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310623349,
-    "wof:lastmodified":1566624455,
+    "wof:lastmodified":1588726989,
     "wof:name":"Pheasant Ridge Mobile Estates",
     "wof:parent_id":102082717,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118443
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/131/063/565/7/1310635657.geojson
+++ b/data/131/063/565/7/1310635657.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-119.27872,34.43527,-119.27872,34.43527",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102086933
+        102086933,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1310635657,
-    "wof:lastmodified":1566624568,
+    "wof:lastmodified":1588726989,
     "wof:name":"Golden Oaks Mobile Estates",
     "wof:parent_id":102086933,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118453
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/655/445/5/1326554455.geojson
+++ b/data/132/655/445/5/1326554455.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.21233,47.32485,-122.21233,47.32485",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102086191
+        102086191,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1326554455,
-    "wof:lastmodified":1566608214,
+    "wof:lastmodified":1588726979,
     "wof:name":"Rio Verde Mobile Estates",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118129
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/664/098/1/1326640981.geojson
+++ b/data/132/664/098/1/1326640981.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.442,27.6959,-82.442,27.6959",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085773
+        102085773,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7217002
     },
     "wof:country":"US",
-    "wof:geomhash":"b0f6e0e99885708eb4573222637f57c2",
+    "wof:geomhash":"f2649974f3a8cea15c1032a39581bd54",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1326640981,
-    "wof:lastmodified":1566608243,
+    "wof:lastmodified":1588726978,
     "wof:name":"Fairmont Mobile Estates",
     "wof:parent_id":102085773,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118115
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -82.44200000000002,
+    -82.442,
     27.6959,
-    -82.44200000000002,
+    -82.442,
     27.6959
 ],
-  "geometry": {"coordinates":[-82.44200000000002,27.6959],"type":"Point"}
+  "geometry": {"coordinates":[-82.44199999999999,27.6959],"type":"Point"}
 }

--- a/data/132/664/573/5/1326645735.geojson
+++ b/data/132/664/573/5/1326645735.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-94.19833,45.07361,-94.19833,45.07361",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404515193,
         85633793,
-        102087815
+        102087815,
+        404515193,
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1326645735,
-    "wof:lastmodified":1566608261,
+    "wof:lastmodified":1588726978,
     "wof:name":"Country Village Mobile Estates",
     "wof:parent_id":404515193,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118109
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/664/579/7/1326645797.geojson
+++ b/data/132/664/579/7/1326645797.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-74.18062,43.19579,-74.18062,43.19579",
@@ -30,22 +32,22 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688543,
         102191575,
-        404522443,
         85633793,
-        102081813
+        102081813,
+        404522443,
+        85688543
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":8085321
     },
     "wof:country":"US",
-    "wof:geomhash":"ee32e02b6fea9b81a97b45fbe092f465",
+    "wof:geomhash":"aa37c9b6649729e427a0c408084a3fa1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -57,20 +59,22 @@
         }
     ],
     "wof:id":1326645797,
-    "wof:lastmodified":1566608293,
+    "wof:lastmodified":1588726978,
     "wof:name":"Lakeside Mobile Estates",
     "wof:parent_id":404522443,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118111
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -74.18061999999998,
+    -74.18062,
     43.19579,
-    -74.18061999999998,
+    -74.18062,
     43.19579
 ],
-  "geometry": {"coordinates":[-74.18061999999998,43.19579],"type":"Point"}
+  "geometry": {"coordinates":[-74.18062,43.19579],"type":"Point"}
 }

--- a/data/132/674/954/7/1326749547.geojson
+++ b/data/132/674/954/7/1326749547.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-82.63278,41.24806,-82.63278,41.24806",
@@ -30,22 +32,22 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688485,
         102191575,
-        404526585,
         85633793,
-        102083735
+        102083735,
+        404526585,
+        85688485
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":7235460
     },
     "wof:country":"US",
-    "wof:geomhash":"4a90594944bce4c87f3d5eba642bf55d",
+    "wof:geomhash":"21bd180030a9e5409029fbedd10a95b9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -57,20 +59,22 @@
         }
     ],
     "wof:id":1326749547,
-    "wof:lastmodified":1566607393,
+    "wof:lastmodified":1588726978,
     "wof:name":"Westwood Mobile Estates",
     "wof:parent_id":404526585,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118107
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -82.63278000000003,
+    -82.63278,
     41.24806,
-    -82.63278000000003,
+    -82.63278,
     41.24806
 ],
-  "geometry": {"coordinates":[-82.63278000000003,41.24806],"type":"Point"}
+  "geometry": {"coordinates":[-82.63278,41.24806],"type":"Point"}
 }

--- a/data/132/675/018/1/1326750181.geojson
+++ b/data/132/675/018/1/1326750181.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-112.54252,46.00215,-112.54252,46.00215",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688617,
-        102085099
+        102085099,
+        85688617
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1326750181,
-    "wof:lastmodified":1566607324,
+    "wof:lastmodified":1588726979,
     "wof:name":"AA Westside Mobile Estates",
     "wof:parent_id":102085099,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118123
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/676/510/9/1326765109.geojson
+++ b/data/132/676/510/9/1326765109.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-106.57666,31.9501,-106.57666,31.9501",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688753,
-        102085989
+        102085989,
+        85688753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1326765109,
-    "wof:lastmodified":1566608080,
+    "wof:lastmodified":1588726985,
     "wof:name":"Mobile Haven Estates Colonia",
     "wof:parent_id":102085989,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118327
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/684/591/1/1326845911.geojson
+++ b/data/132/684/591/1/1326845911.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-85.93972,42.45972,-85.93972,42.45972",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404506777,
         85633793,
-        102083043
+        102083043,
+        404506777,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1326845911,
-    "wof:lastmodified":1566608176,
+    "wof:lastmodified":1588726979,
     "wof:name":"Swan Lake Mobile Estates",
     "wof:parent_id":404506777,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118127
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/686/663/5/1326866635.geojson
+++ b/data/132/686/663/5/1326866635.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-112.01181,33.47532,-112.01181,33.47532",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102087421
+        102087421,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1326866635,
-    "wof:lastmodified":1566607291,
+    "wof:lastmodified":1588726985,
     "wof:name":"Rancho Mobile Estates",
     "wof:parent_id":102087421,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118337
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/694/603/1/1326946031.geojson
+++ b/data/132/694/603/1/1326946031.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.4502,47.13233,-122.4502,47.13233",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087547
+        102087547,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1326946031,
-    "wof:lastmodified":1566607556,
+    "wof:lastmodified":1588726985,
     "wof:name":"One Hundred Thirty - Eighth Park Mobile Estates",
     "wof:parent_id":102087547,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118335
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/694/951/3/1326949513.geojson
+++ b/data/132/694/951/3/1326949513.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-70.69837,41.95149,-70.69837,41.95149",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688645,
         102191575,
-        404476561,
         85633793,
-        102084367
+        102084367,
+        404476561,
+        85688645
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1326949513,
-    "wof:lastmodified":1566607589,
+    "wof:lastmodified":1588726985,
     "wof:name":"Plymouth Mobile Estates",
     "wof:parent_id":404476561,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118333
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/704/629/7/1327046297.geojson
+++ b/data/132/704/629/7/1327046297.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-95.43778,42.71054,-95.43778,42.71054",
@@ -30,14 +32,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688713,
-        102086371
+        102086371,
+        85688713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,12 +57,14 @@
         }
     ],
     "wof:id":1327046297,
-    "wof:lastmodified":1566608009,
+    "wof:lastmodified":1588726979,
     "wof:name":"Southern Acres Mobile Estates",
     "wof:parent_id":102086371,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118133
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/715/380/7/1327153807.geojson
+++ b/data/132/715/380/7/1327153807.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-77.0733,35.565,-77.0733,35.565",
@@ -30,14 +32,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688773,
-        102080941
+        102080941,
+        85688773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,12 +57,14 @@
         }
     ],
     "wof:id":1327153807,
-    "wof:lastmodified":1566607793,
+    "wof:lastmodified":1588726979,
     "wof:name":"Maryanna Mobile Estates",
     "wof:parent_id":102080941,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118117
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/715/862/7/1327158627.geojson
+++ b/data/132/715/862/7/1327158627.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-118.41872,37.38049,-118.41872,37.38049",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102087577
+        102087577,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1327158627,
-    "wof:lastmodified":1566607781,
+    "wof:lastmodified":1588726979,
     "wof:name":"Glenwood Mobile Estates",
     "wof:parent_id":102087577,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118119
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/725/778/5/1327257785.geojson
+++ b/data/132/725/778/5/1327257785.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-93.25078,30.16678,-93.25078,30.16678",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102081035
+        102081035,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1327257785,
-    "wof:lastmodified":1566607671,
+    "wof:lastmodified":1588726979,
     "wof:name":"Southtowner Mobile Estates",
     "wof:parent_id":102081035,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118121
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/735/287/9/1327352879.geojson
+++ b/data/132/735/287/9/1327352879.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-80.1755,25.9972,-80.1755,25.9972",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102084727
+        102084727,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1327352879,
-    "wof:lastmodified":1566607939,
+    "wof:lastmodified":1588726980,
     "wof:name":"Hollywood Mobile Estates",
     "wof:parent_id":102084727,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118151
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/132/735/823/7/1327358237.geojson
+++ b/data/132/735/823/7/1327358237.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-117.8309,34.48305,-117.8309,34.48305",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102086957
+        102086957,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1327358237,
-    "wof:lastmodified":1566607970,
+    "wof:lastmodified":1588726979,
     "wof:name":"Country Mobile Estates",
     "wof:parent_id":102086957,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118125
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/327/782/1/1343277821.geojson
+++ b/data/134/327/782/1/1343277821.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-93.17749,30.15641,-93.17749,30.15641",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102081035
+        102081035,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1343277821,
-    "wof:lastmodified":1566611060,
+    "wof:lastmodified":1588726980,
     "wof:name":"Fairview Recreational Mobile Estates",
     "wof:parent_id":102081035,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118173
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/337/458/5/1343374585.geojson
+++ b/data/134/337/458/5/1343374585.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.1502,48.05203,-122.1502,48.05203",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087537
+        102087537,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1343374585,
-    "wof:lastmodified":1566610208,
+    "wof:lastmodified":1588726980,
     "wof:name":"Glenwood Mobile Estates",
     "wof:parent_id":102087537,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118171
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/337/482/3/1343374823.geojson
+++ b/data/134/337/482/3/1343374823.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-85.54833,43.23056,-85.54833,43.23056",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688599,
         102191575,
-        404509035,
         85633793,
-        102083023
+        102083023,
+        404509035,
+        85688599
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1343374823,
-    "wof:lastmodified":1566610165,
+    "wof:lastmodified":1588726980,
     "wof:name":"Cedar Springs Mobile Estates",
     "wof:parent_id":404509035,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118169
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/347/837/7/1343478377.geojson
+++ b/data/134/347/837/7/1343478377.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.76567,28.93213,-81.76567,28.93213",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102084775
+        102084775,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1343478377,
-    "wof:lastmodified":1566610582,
+    "wof:lastmodified":1588726981,
     "wof:name":"Sunlake Estates Mobile Park",
     "wof:parent_id":102084775,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118199
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/358/085/3/1343580853.geojson
+++ b/data/134/358/085/3/1343580853.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-121.14964,36.18136,-121.14964,36.18136",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:azb_x_preferred":[
         "\u067e\u0627\u06cc\u0646 \u06a9\u0627\u0646\u06cc\u0648\u0646"
@@ -62,8 +64,8 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102080859
+        102080859,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -82,12 +84,14 @@
         }
     ],
     "wof:id":1343580853,
-    "wof:lastmodified":1566610781,
+    "wof:lastmodified":1588726981,
     "wof:name":"Pine Canyon Mobile Estates",
     "wof:parent_id":102080859,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118205
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/359/810/3/1343598103.geojson
+++ b/data/134/359/810/3/1343598103.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-110.95453,32.28496,-110.95453,32.28496",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102081135
+        102081135,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1343598103,
-    "wof:lastmodified":1566610651,
+    "wof:lastmodified":1588726981,
     "wof:name":"Vista Del Norte Mobile Estates",
     "wof:parent_id":102081135,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118201
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/367/823/1/1343678231.geojson
+++ b/data/134/367/823/1/1343678231.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.68244,38.85818,-76.68244,38.85818",
@@ -29,7 +31,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
         "Maryland Mobile Estates"
@@ -41,8 +43,8 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688501,
-        102083469
+        102083469,
+        85688501
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -60,12 +62,14 @@
         }
     ],
     "wof:id":1343678231,
-    "wof:lastmodified":1566610858,
+    "wof:lastmodified":1588726980,
     "wof:name":"Maryland Mobile Estates",
     "wof:parent_id":102083469,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118175
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/378/790/1/1343787901.geojson
+++ b/data/134/378/790/1/1343787901.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-97.61799,38.85762,-97.61799,38.85762",
@@ -30,15 +32,15 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688555,
         102191575,
-        404502927,
         85633793,
-        102083453
+        102083453,
+        404502927,
+        85688555
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -57,12 +59,14 @@
         }
     ],
     "wof:id":1343787901,
-    "wof:lastmodified":1566610592,
+    "wof:lastmodified":1588726981,
     "wof:name":"Del - Ray Mobile Estates",
     "wof:parent_id":404502927,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118209
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/378/795/1/1343787951.geojson
+++ b/data/134/378/795/1/1343787951.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-90.97835,30.25177,-90.97835,30.25177",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688735,
-        102086687
+        102086687,
+        85688735
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1343787951,
-    "wof:lastmodified":1566610629,
+    "wof:lastmodified":1588726980,
     "wof:name":"Twin Lakes Mobile Estates",
     "wof:parent_id":102086687,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118165
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/387/420/7/1343874207.geojson
+++ b/data/134/387/420/7/1343874207.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.1543,31.9948,-81.1543,31.9948",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688535,
-        102082337
+        102082337,
+        85688535
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1343874207,
-    "wof:lastmodified":1566611142,
+    "wof:lastmodified":1588726981,
     "wof:name":"Southside Mobile Estates",
     "wof:parent_id":102082337,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118207
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/408/094/5/1344080945.geojson
+++ b/data/134/408/094/5/1344080945.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.18814,47.75511,-122.18814,47.75511",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102086191
+        102086191,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1344080945,
-    "wof:lastmodified":1566610341,
+    "wof:lastmodified":1588726981,
     "wof:name":"Riverside Mobile Estates",
     "wof:parent_id":102086191,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118197
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/134/427/300/5/1344273005.geojson
+++ b/data/134/427/300/5/1344273005.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.27689,47.14229,-122.27689,47.14229",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688623,
-        102087547
+        102087547,
+        85688623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1344273005,
-    "wof:lastmodified":1566611005,
+    "wof:lastmodified":1588726980,
     "wof:name":"San Souci Mobile Estates",
     "wof:parent_id":102087547,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118163
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/136/000/983/9/1360009839.geojson
+++ b/data/136/000/983/9/1360009839.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-94.10857,41.85971,-94.10857,41.85971",
@@ -30,14 +32,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688713,
-        102086525
+        102086525,
+        85688713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,12 +57,14 @@
         }
     ],
     "wof:id":1360009839,
-    "wof:lastmodified":1566625035,
+    "wof:lastmodified":1588726981,
     "wof:name":"Bar-Jac Mobile Estates",
     "wof:parent_id":102086525,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118187
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/136/030/145/7/1360301457.geojson
+++ b/data/136/030/145/7/1360301457.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-81.42528,27.48719,-81.42528,27.48719",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688651,
-        102085801
+        102085801,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1360301457,
-    "wof:lastmodified":1566625126,
+    "wof:lastmodified":1588726982,
     "wof:name":"Sebring Mobile Estates",
     "wof:parent_id":102085801,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118235
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/136/030/970/3/1360309703.geojson
+++ b/data/136/030/970/3/1360309703.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-122.28167,40.46694,-122.28167,40.46694",
@@ -29,14 +31,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102083577
+        102083577,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -54,12 +56,14 @@
         }
     ],
     "wof:id":1360309703,
-    "wof:lastmodified":1566625124,
+    "wof:lastmodified":1588726982,
     "wof:name":"Riviera Mobile Estates",
     "wof:parent_id":102083577,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118223
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/136/030/991/3/1360309913.geojson
+++ b/data/136/030/991/3/1360309913.geojson
@@ -3,7 +3,9 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-05-05",
     "edtf:inception":"uuuu",
+    "edtf:superseded":"2020-05-05",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
     "geom:bbox":"-76.76333,37.34139,-76.76333,37.34139",
@@ -29,21 +31,21 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "src:geom":"geonames",
     "wof:belongsto":[
         102191575,
         85633793,
-        85688747,
-        102085967
+        102085967,
+        85688747
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":6332174
     },
     "wof:country":"US",
-    "wof:geomhash":"68919115649c420f3f046ffc87121c09",
+    "wof:geomhash":"c83379c39541aa822e3b67efbc8b369f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -54,20 +56,22 @@
         }
     ],
     "wof:id":1360309913,
-    "wof:lastmodified":1566625100,
+    "wof:lastmodified":1588726982,
     "wof:name":"Mobile Estates",
     "wof:parent_id":102085967,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1713118237
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },
   "bbox": [
-    -76.76333000000002,
+    -76.76333,
     37.34139,
-    -76.76333000000002,
+    -76.76333,
     37.34139
 ],
-  "geometry": {"coordinates":[-76.76333000000002,37.34139],"type":"Point"}
+  "geometry": {"coordinates":[-76.76333,37.34139],"type":"Point"}
 }

--- a/data/171/311/810/7/1713118107.geojson
+++ b/data/171/311/810/7/1713118107.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118107,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.63278,41.24806,-82.63278,41.24806",
+    "geom:latitude":41.24806,
+    "geom:longitude":-82.63278,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"77",
+    "gn:admin3_code":"57302.0",
+    "gn:asciiname":"Westwood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":215,
+    "gn:elevation":"216.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7235460,
+    "gn:latitude":41.24806,
+    "gn:longitude":-82.63278,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Westwood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.65278,41.22806,-82.61278,41.26806",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083735,
+        404526585,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7235460
+    },
+    "wof:country":"US",
+    "wof:geomhash":"21bd180030a9e5409029fbedd10a95b9",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118107,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083735,
+            "localadmin_id":404526585,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118107,
+    "wof:lastmodified":1588726978,
+    "wof:name":"Westwood Mobile Estates",
+    "wof:parent_id":404526585,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326749547
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.63278,
+    41.24806,
+    -82.63278,
+    41.24806
+],
+  "geometry": {"coordinates":[-82.63278,41.24806],"type":"Point"}
+}

--- a/data/171/311/810/9/1713118109.geojson
+++ b/data/171/311/810/9/1713118109.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118109,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-94.19833,45.07361,-94.19833,45.07361",
+    "geom:latitude":45.07361,
+    "geom:longitude":-94.19833,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"171.0",
+    "gn:admin3_code":"12430.0",
+    "gn:asciiname":"Country Village Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":319,
+    "gn:elevation":"318.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5022189,
+    "gn:latitude":45.07361,
+    "gn:longitude":-94.19833,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Country Village Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-94.21833,45.05361,-94.17833,45.09361",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087815,
+        404515193,
+        85688727
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5022189
+    },
+    "wof:country":"US",
+    "wof:geomhash":"88933ca7d53c7dad06257f53453fa83d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118109,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087815,
+            "localadmin_id":404515193,
+            "locality_id":-1,
+            "region_id":85688727
+        }
+    ],
+    "wof:id":1713118109,
+    "wof:lastmodified":1588726978,
+    "wof:name":"Country Village Mobile Estates",
+    "wof:parent_id":404515193,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326645735
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -94.19833,
+    45.07361,
+    -94.19833,
+    45.07361
+],
+  "geometry": {"coordinates":[-94.19833,45.07361],"type":"Point"}
+}

--- a/data/171/311/811/1/1713118111.geojson
+++ b/data/171/311/811/1/1713118111.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118111,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-74.18062,43.19579,-74.18062,43.19579",
+    "geom:latitude":43.19579,
+    "geom:longitude":-74.18062,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"35.0",
+    "gn:admin3_code":"51407.0",
+    "gn:asciiname":"Lakeside Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":244,
+    "gn:elevation":"240.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8085321,
+    "gn:latitude":43.19579,
+    "gn:longitude":-74.18062,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Lakeside Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-74.20062,43.17579,-74.16062,43.21579",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081813,
+        404522443,
+        85688543
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8085321
+    },
+    "wof:country":"US",
+    "wof:geomhash":"aa37c9b6649729e427a0c408084a3fa1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118111,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081813,
+            "localadmin_id":404522443,
+            "locality_id":-1,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1713118111,
+    "wof:lastmodified":1588726978,
+    "wof:name":"Lakeside Mobile Estates",
+    "wof:parent_id":404522443,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326645797
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -74.18062,
+    43.19579,
+    -74.18062,
+    43.19579
+],
+  "geometry": {"coordinates":[-74.18062,43.19579],"type":"Point"}
+}

--- a/data/171/311/811/5/1713118115.geojson
+++ b/data/171/311/811/5/1713118115.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118115,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.442,27.6959,-82.442,27.6959",
+    "geom:latitude":27.6959,
+    "geom:longitude":-82.442,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"57",
+    "gn:asciiname":"Fairmont Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":7,
+    "gn:elevation":"4.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7217002,
+    "gn:latitude":27.6959,
+    "gn:longitude":-82.442,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Fairmont Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.462,27.6759,-82.422,27.7159",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085773,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7217002
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f2649974f3a8cea15c1032a39581bd54",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118115,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085773,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118115,
+    "wof:lastmodified":1588726978,
+    "wof:name":"Fairmont Mobile Estates",
+    "wof:parent_id":102085773,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326640981
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.442,
+    27.6959,
+    -82.442,
+    27.6959
+],
+  "geometry": {"coordinates":[-82.44199999999999,27.6959],"type":"Point"}
+}

--- a/data/171/311/811/7/1713118117.geojson
+++ b/data/171/311/811/7/1713118117.geojson
@@ -1,0 +1,77 @@
+{
+  "id": 1713118117,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-77.0733,35.565,-77.0733,35.565",
+    "geom:latitude":35.565,
+    "geom:longitude":-77.0733,
+    "gn:admin1_code":"NC",
+    "gn:admin2_code":"13",
+    "gn:admin3_code":"93904.0",
+    "gn:asciiname":"Maryanna Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":6,
+    "gn:elevation":"4.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7230375,
+    "gn:latitude":35.565,
+    "gn:longitude":-77.0733,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Maryanna Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-77.0933,35.545,-77.0533,35.585",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102080941,
+        85688773
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7230375
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f290276509117e7f84f8ef42682edaf7",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118117,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102080941,
+            "locality_id":-1,
+            "region_id":85688773
+        }
+    ],
+    "wof:id":1713118117,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Maryanna Mobile Estates",
+    "wof:parent_id":102080941,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1327153807
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -77.0733,
+    35.565,
+    -77.0733,
+    35.565
+],
+  "geometry": {"coordinates":[-77.0733,35.565],"type":"Point"}
+}

--- a/data/171/311/811/9/1713118119.geojson
+++ b/data/171/311/811/9/1713118119.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118119,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-118.41872,37.38049,-118.41872,37.38049",
+    "geom:latitude":37.38049,
+    "geom:longitude":-118.41872,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"27",
+    "gn:asciiname":"Glenwood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":1279,
+    "gn:elevation":"1278.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5352505,
+    "gn:latitude":37.38049,
+    "gn:longitude":-118.41872,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Glenwood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-118.43872,37.36049,-118.39872,37.40049",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087577,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5352505
+    },
+    "wof:country":"US",
+    "wof:geomhash":"533f1ba093091839eebcd58fc91e6d87",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118119,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087577,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118119,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Glenwood Mobile Estates",
+    "wof:parent_id":102087577,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1327158627
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -118.41872,
+    37.38049,
+    -118.41872,
+    37.38049
+],
+  "geometry": {"coordinates":[-118.41871999999999,37.38049],"type":"Point"}
+}

--- a/data/171/311/812/1/1713118121.geojson
+++ b/data/171/311/812/1/1713118121.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118121,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-93.25078,30.16678,-93.25078,30.16678",
+    "geom:latitude":30.16678,
+    "geom:longitude":-93.25078,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"19.0",
+    "gn:asciiname":"Southtowner Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":8,
+    "gn:elevation":"4.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7708348,
+    "gn:latitude":30.16678,
+    "gn:longitude":-93.25078,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Southtowner Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-93.27078,30.14678,-93.23078,30.18678",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081035,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7708348
+    },
+    "wof:country":"US",
+    "wof:geomhash":"0e72ff209481d5e8d27f87613bae8747",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118121,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081035,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118121,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Southtowner Mobile Estates",
+    "wof:parent_id":102081035,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1327257785
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -93.25078,
+    30.16678,
+    -93.25078,
+    30.16678
+],
+  "geometry": {"coordinates":[-93.25078000000001,30.16678],"type":"Point"}
+}

--- a/data/171/311/812/3/1713118123.geojson
+++ b/data/171/311/812/3/1713118123.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118123,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-112.54252,46.00215,-112.54252,46.00215",
+    "geom:latitude":46.00215,
+    "geom:longitude":-112.54252,
+    "gn:admin1_code":"MT",
+    "gn:admin2_code":"93",
+    "gn:asciiname":"AA Westside Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":1685,
+    "gn:elevation":"1686.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5636471,
+    "gn:latitude":46.00215,
+    "gn:longitude":-112.54252,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"AA Westside Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Denver",
+    "iso:country":"US",
+    "lbl:bbox":"-112.56252,45.98215,-112.52252,46.02215",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085099,
+        85688617
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5636471
+    },
+    "wof:country":"US",
+    "wof:geomhash":"d3a6ab7b231acc68a17adc3448a6de8f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118123,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085099,
+            "locality_id":-1,
+            "region_id":85688617
+        }
+    ],
+    "wof:id":1713118123,
+    "wof:lastmodified":1588726979,
+    "wof:name":"AA Westside Mobile Estates",
+    "wof:parent_id":102085099,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326750181
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -112.54252,
+    46.00215,
+    -112.54252,
+    46.00215
+],
+  "geometry": {"coordinates":[-112.54252,46.00215],"type":"Point"}
+}

--- a/data/171/311/812/5/1713118125.geojson
+++ b/data/171/311/812/5/1713118125.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118125,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-117.8309,34.48305,-117.8309,34.48305",
+    "geom:latitude":34.48305,
+    "geom:longitude":-117.8309,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"37.0",
+    "gn:asciiname":"Country Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":1053,
+    "gn:elevation":"1050.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5340091,
+    "gn:latitude":34.48305,
+    "gn:longitude":-117.8309,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Country Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-117.8509,34.46305,-117.8109,34.50305",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086957,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5340091
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3079b35cff9e2a43abbe7abad3ea2496",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118125,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086957,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118125,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Country Mobile Estates",
+    "wof:parent_id":102086957,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1327358237
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -117.8309,
+    34.48305,
+    -117.8309,
+    34.48305
+],
+  "geometry": {"coordinates":[-117.8309,34.48305],"type":"Point"}
+}

--- a/data/171/311/812/7/1713118127.geojson
+++ b/data/171/311/812/7/1713118127.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118127,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.93972,42.45972,-85.93972,42.45972",
+    "geom:latitude":42.45972,
+    "geom:longitude":-85.93972,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"5.0",
+    "gn:admin3_code":"15200.0",
+    "gn:asciiname":"Swan Lake Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":224,
+    "gn:elevation":"213.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7308647,
+    "gn:latitude":42.45972,
+    "gn:longitude":-85.93972,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Swan Lake Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-85.95972,42.43972,-85.91972,42.47972",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083043,
+        404506777,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7308647
+    },
+    "wof:country":"US",
+    "wof:geomhash":"0f9bf157bef151358294d7e39303caad",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118127,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083043,
+            "localadmin_id":404506777,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118127,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Swan Lake Mobile Estates",
+    "wof:parent_id":404506777,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326845911
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.93972,
+    42.45972,
+    -85.93972,
+    42.45972
+],
+  "geometry": {"coordinates":[-85.93971999999999,42.45972],"type":"Point"}
+}

--- a/data/171/311/812/9/1713118129.geojson
+++ b/data/171/311/812/9/1713118129.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118129,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.21233,47.32485,-122.21233,47.32485",
+    "geom:latitude":47.32485,
+    "geom:longitude":-122.21233,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"33.0",
+    "gn:asciiname":"Rio Verde Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":17,
+    "gn:elevation":"18.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713977,
+    "gn:latitude":47.32485,
+    "gn:longitude":-122.21233,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Rio Verde Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.23233,47.30485,-122.19233,47.34485",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086191,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713977
+    },
+    "wof:country":"US",
+    "wof:geomhash":"9f0f15e887b79de7c039d92f36fb41a2",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118129,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086191,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118129,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Rio Verde Mobile Estates",
+    "wof:parent_id":102086191,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326554455
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.21233,
+    47.32485,
+    -122.21233,
+    47.32485
+],
+  "geometry": {"coordinates":[-122.21232999999999,47.32485],"type":"Point"}
+}

--- a/data/171/311/813/3/1713118133.geojson
+++ b/data/171/311/813/3/1713118133.geojson
@@ -1,0 +1,77 @@
+{
+  "id": 1713118133,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-95.43778,42.71054,-95.43778,42.71054",
+    "geom:latitude":42.71054,
+    "geom:longitude":-95.43778,
+    "gn:admin1_code":"IA",
+    "gn:admin2_code":"35.0",
+    "gn:admin3_code":"93336.0",
+    "gn:asciiname":"Southern Acres Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":419,
+    "gn:elevation":"420.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4877066,
+    "gn:latitude":42.71054,
+    "gn:longitude":-95.43778,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Southern Acres Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-95.45778,42.69054,-95.41778,42.73054",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086371,
+        85688713
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4877066
+    },
+    "wof:country":"US",
+    "wof:geomhash":"0a283b39273d8a86e2f3df9db8297da2",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118133,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086371,
+            "locality_id":-1,
+            "region_id":85688713
+        }
+    ],
+    "wof:id":1713118133,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Southern Acres Mobile Estates",
+    "wof:parent_id":102086371,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1327046297
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -95.43778,
+    42.71054,
+    -95.43778,
+    42.71054
+],
+  "geometry": {"coordinates":[-95.43778,42.71054],"type":"Point"}
+}

--- a/data/171/311/813/5/1713118135.geojson
+++ b/data/171/311/813/5/1713118135.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118135,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.48504,48.71614,-122.48504,48.71614",
+    "geom:latitude":48.71614,
+    "geom:longitude":-122.48504,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"73.0",
+    "gn:asciiname":"South End Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":34,
+    "gn:elevation":"35.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714002,
+    "gn:latitude":48.71614,
+    "gn:longitude":-122.48504,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"South End Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.50504,48.69614,-122.46504,48.73614",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085363,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714002
+    },
+    "wof:country":"US",
+    "wof:geomhash":"cd5dcd556232244bae05f509dba79538",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118135,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085363,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118135,
+    "wof:lastmodified":1588726979,
+    "wof:name":"South End Mobile Estates",
+    "wof:parent_id":102085363,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309940475
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.48504,
+    48.71614,
+    -122.48504,
+    48.71614
+],
+  "geometry": {"coordinates":[-122.48504,48.71614],"type":"Point"}
+}

--- a/data/171/311/813/7/1713118137.geojson
+++ b/data/171/311/813/7/1713118137.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118137,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.4454,27.4689,-81.4454,27.4689",
+    "geom:latitude":27.4689,
+    "geom:longitude":-81.4454,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"55.0",
+    "gn:asciiname":"Francis I Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":37,
+    "gn:elevation":"33.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7193087,
+    "gn:latitude":27.4689,
+    "gn:longitude":-81.4454,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Francis I Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.4654,27.4489,-81.4254,27.4889",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085801,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7193087
+    },
+    "wof:country":"US",
+    "wof:geomhash":"bc68bc0274ac19156f732c76801daf31",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118137,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085801,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118137,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Francis I Mobile Estates",
+    "wof:parent_id":102085801,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309731587
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.4454,
+    27.4689,
+    -81.4454,
+    27.4689
+],
+  "geometry": {"coordinates":[-81.44540000000001,27.4689],"type":"Point"}
+}

--- a/data/171/311/813/9/1713118139.geojson
+++ b/data/171/311/813/9/1713118139.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118139,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.20334,47.81848,-122.20334,47.81848",
+    "geom:latitude":47.81848,
+    "geom:longitude":-122.20334,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"61.0",
+    "gn:asciiname":"Kennard Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":57,
+    "gn:elevation":"56.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714016,
+    "gn:latitude":47.81848,
+    "gn:longitude":-122.20334,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Kennard Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.22334,47.79848,-122.18334,47.83848",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087537,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714016
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6cd69b3aa410f6634dfee38049c447f9",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118139,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087537,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118139,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Kennard Mobile Estates",
+    "wof:parent_id":102087537,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309731799
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.20334,
+    47.81848,
+    -122.20334,
+    47.81848
+],
+  "geometry": {"coordinates":[-122.20334,47.81848],"type":"Point"}
+}

--- a/data/171/311/814/1/1713118141.geojson
+++ b/data/171/311/814/1/1713118141.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118141,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.47117,48.89326,-122.47117,48.89326",
+    "geom:latitude":48.89326,
+    "geom:longitude":-122.47117,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"73.0",
+    "gn:asciiname":"Royal Coachman Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":25,
+    "gn:elevation":"26.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714208,
+    "gn:latitude":48.89326,
+    "gn:longitude":-122.47117,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Royal Coachman Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.49117,48.87326,-122.45117,48.91326",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085363,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714208
+    },
+    "wof:country":"US",
+    "wof:geomhash":"986b60665d2c01d5904094ebb6cbf40d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118141,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085363,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118141,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Royal Coachman Mobile Estates",
+    "wof:parent_id":102085363,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309921411
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.47117,
+    48.89326,
+    -122.47117,
+    48.89326
+],
+  "geometry": {"coordinates":[-122.47117,48.89326],"type":"Point"}
+}

--- a/data/171/311/814/3/1713118143.geojson
+++ b/data/171/311/814/3/1713118143.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118143,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-70.82922,42.98176,-70.82922,42.98176",
+    "geom:latitude":42.98176,
+    "geom:longitude":-70.82922,
+    "gn:admin1_code":"NH",
+    "gn:admin2_code":"15.0",
+    "gn:admin3_code":"54580.0",
+    "gn:asciiname":"Shel Al Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":26,
+    "gn:elevation":"21.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5092607,
+    "gn:latitude":42.98176,
+    "gn:longitude":-70.82922,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Shel Al Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-70.84922,42.96176,-70.80922,43.00176",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086507,
+        404476771,
+        85688689
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5092607
+    },
+    "wof:country":"US",
+    "wof:geomhash":"c6f53d1e8791fdf76cca33fa9b9ea971",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118143,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086507,
+            "localadmin_id":404476771,
+            "locality_id":-1,
+            "region_id":85688689
+        }
+    ],
+    "wof:id":1713118143,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Shel Al Mobile Estates",
+    "wof:parent_id":404476771,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309930183
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -70.82922,
+    42.98176,
+    -70.82922,
+    42.98176
+],
+  "geometry": {"coordinates":[-70.82922000000001,42.98176],"type":"Point"}
+}

--- a/data/171/311/814/5/1713118145.geojson
+++ b/data/171/311/814/5/1713118145.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118145,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.79432,36.78335,-76.79432,36.78335",
+    "geom:latitude":36.78335,
+    "geom:longitude":-76.79432,
+    "gn:admin1_code":"VA",
+    "gn:admin2_code":"93",
+    "gn:asciiname":"Oaks Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":21,
+    "gn:elevation":"19.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7238758,
+    "gn:latitude":36.78335,
+    "gn:longitude":-76.79432,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Oaks Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.81432,36.76335,-76.77432,36.80335",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086709,
+        85688747
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7238758
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6d36498a4841f09df89a9383a398b4dd",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118145,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086709,
+            "locality_id":-1,
+            "region_id":85688747
+        }
+    ],
+    "wof:id":1713118145,
+    "wof:lastmodified":1588726979,
+    "wof:name":"Oaks Mobile Estates",
+    "wof:parent_id":102086709,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243091929
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.79432,
+    36.78335,
+    -76.79432,
+    36.78335
+],
+  "geometry": {"coordinates":[-76.79432,36.78335],"type":"Point"}
+}

--- a/data/171/311/814/7/1713118147.geojson
+++ b/data/171/311/814/7/1713118147.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118147,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.2883,27.9684,-82.2883,27.9684",
+    "geom:latitude":27.9684,
+    "geom:longitude":-82.2883,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"57",
+    "gn:asciiname":"Brandon Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":26,
+    "gn:elevation":"14.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7217098,
+    "gn:latitude":27.9684,
+    "gn:longitude":-82.2883,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Brandon Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.3083,27.9484,-82.2683,27.9884",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085773,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7217098
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3992775cead09f29c53ad3e33c4bd2b7",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118147,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085773,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118147,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Brandon Mobile Estates",
+    "wof:parent_id":102085773,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243574065
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.2883,
+    27.9684,
+    -82.2883,
+    27.9684
+],
+  "geometry": {"coordinates":[-82.28830000000001,27.9684],"type":"Point"}
+}

--- a/data/171/311/815/1/1713118151.geojson
+++ b/data/171/311/815/1/1713118151.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118151,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.1755,25.9972,-80.1755,25.9972",
+    "geom:latitude":25.9972,
+    "geom:longitude":-80.1755,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"11.0",
+    "gn:asciiname":"Hollywood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":10,
+    "gn:elevation":"2.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7190761,
+    "gn:latitude":25.9972,
+    "gn:longitude":-80.1755,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Hollywood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-80.1955,25.9772,-80.1555,26.0172",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084727,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7190761
+    },
+    "wof:country":"US",
+    "wof:geomhash":"ea3e89f3e8a3f142c54ad3c2332e7a12",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118151,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084727,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118151,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Hollywood Mobile Estates",
+    "wof:parent_id":102084727,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1327352879
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.1755,
+    25.9972,
+    -80.1755,
+    25.9972
+],
+  "geometry": {"coordinates":[-80.1755,25.9972],"type":"Point"}
+}

--- a/data/171/311/815/3/1713118153.geojson
+++ b/data/171/311/815/3/1713118153.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118153,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.21264,26.00474,-80.21264,26.00474",
+    "geom:latitude":26.00474,
+    "geom:longitude":-80.21264,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"11.0",
+    "gn:asciiname":"New England Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":10,
+    "gn:elevation":"3.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7190763,
+    "gn:latitude":26.00474,
+    "gn:longitude":-80.21264,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"New England Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-80.23264,25.98474,-80.19264,26.02474",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084727,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7190763
+    },
+    "wof:country":"US",
+    "wof:geomhash":"a890d54e60a1285769d4d5463544a495",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118153,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084727,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118153,
+    "wof:lastmodified":1588726980,
+    "wof:name":"New England Mobile Estates",
+    "wof:parent_id":102084727,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243570191
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.21264,
+    26.00474,
+    -80.21264,
+    26.00474
+],
+  "geometry": {"coordinates":[-80.21263999999999,26.00474],"type":"Point"}
+}

--- a/data/171/311/815/5/1713118155.geojson
+++ b/data/171/311/815/5/1713118155.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118155,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-92.08708,30.24428,-92.08708,30.24428",
+    "geom:latitude":30.24428,
+    "geom:longitude":-92.08708,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"55.0",
+    "gn:asciiname":"Landall Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":12,
+    "gn:elevation":"10.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7707996,
+    "gn:latitude":30.24428,
+    "gn:longitude":-92.08708,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Landall Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-92.10708,30.22428,-92.06708,30.26428",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081919,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7707996
+    },
+    "wof:country":"US",
+    "wof:geomhash":"331027e08a1fa4bb81aaf1a1f946c0fe",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118155,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081919,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118155,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Landall Mobile Estates",
+    "wof:parent_id":102081919,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243480283
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -92.08708,
+    30.24428,
+    -92.08708,
+    30.24428
+],
+  "geometry": {"coordinates":[-92.08708,30.24428],"type":"Point"}
+}

--- a/data/171/311/815/7/1713118157.geojson
+++ b/data/171/311/815/7/1713118157.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118157,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.47856,38.2579,-76.47856,38.2579",
+    "geom:latitude":38.2579,
+    "geom:longitude":-76.47856,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"37.0",
+    "gn:asciiname":"Suburban Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":26,
+    "gn:elevation":"25.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4370576,
+    "gn:latitude":38.2579,
+    "gn:longitude":-76.47856,
+    "gn:modification_date":"2010-02-19",
+    "gn:name":"Suburban Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.49856,38.2379,-76.45856,38.2779",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082729,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4370576
+    },
+    "wof:country":"US",
+    "wof:geomhash":"34e9edced53ae32dda4402bbb73f5ecb",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118157,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082729,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118157,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Suburban Mobile Estates",
+    "wof:parent_id":102082729,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242893307
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.47856,
+    38.2579,
+    -76.47856,
+    38.2579
+],
+  "geometry": {"coordinates":[-76.47856,38.2579],"type":"Point"}
+}

--- a/data/171/311/815/9/1713118159.geojson
+++ b/data/171/311/815/9/1713118159.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118159,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.80554,27.71153,-81.80554,27.71153",
+    "geom:latitude":27.71153,
+    "geom:longitude":-81.80554,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"105.0",
+    "gn:asciiname":"Hammock Lake Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":33,
+    "gn:elevation":"28.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7190499,
+    "gn:latitude":27.71153,
+    "gn:longitude":-81.80554,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Hammock Lake Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.82554,27.69153,-81.78554,27.73153",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085843,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7190499
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6587ada67ab5a0114e0728f3009db614",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118159,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085843,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118159,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Hammock Lake Mobile Estates",
+    "wof:parent_id":102085843,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242893221
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.80554,
+    27.71153,
+    -81.80554,
+    27.71153
+],
+  "geometry": {"coordinates":[-81.80553999999999,27.71153],"type":"Point"}
+}

--- a/data/171/311/816/1/1713118161.geojson
+++ b/data/171/311/816/1/1713118161.geojson
@@ -1,0 +1,77 @@
+{
+  "id": 1713118161,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-91.55794,40.96364,-91.55794,40.96364",
+    "geom:latitude":40.96364,
+    "geom:longitude":-91.55794,
+    "gn:admin1_code":"IA",
+    "gn:admin2_code":"87.0",
+    "gn:admin3_code":"93036.0",
+    "gn:asciiname":"Woodside Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":221,
+    "gn:elevation":"218.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4882447,
+    "gn:latitude":40.96364,
+    "gn:longitude":-91.55794,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Woodside Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-91.57794,40.94364,-91.53794,40.98364",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086629,
+        85688713
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4882447
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f7581a8f0541d4db73e7e940ae390ece",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118161,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086629,
+            "locality_id":-1,
+            "region_id":85688713
+        }
+    ],
+    "wof:id":1713118161,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Woodside Mobile Estates",
+    "wof:parent_id":102086629,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243570029
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -91.55794,
+    40.96364,
+    -91.55794,
+    40.96364
+],
+  "geometry": {"coordinates":[-91.55794,40.96364],"type":"Point"}
+}

--- a/data/171/311/816/3/1713118163.geojson
+++ b/data/171/311/816/3/1713118163.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118163,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.27689,47.14229,-122.27689,47.14229",
+    "geom:latitude":47.14229,
+    "geom:longitude":-122.27689,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"San Souci Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":139,
+    "gn:elevation":"140.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713257,
+    "gn:latitude":47.14229,
+    "gn:longitude":-122.27689,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"San Souci Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.29689,47.12229,-122.25689,47.16229",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087547,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713257
+    },
+    "wof:country":"US",
+    "wof:geomhash":"1dcbe55258304dc746f0f86b0d5fe6d9",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118163,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087547,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118163,
+    "wof:lastmodified":1588726980,
+    "wof:name":"San Souci Mobile Estates",
+    "wof:parent_id":102087547,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1344273005
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.27689,
+    47.14229,
+    -122.27689,
+    47.14229
+],
+  "geometry": {"coordinates":[-122.27688999999999,47.14229],"type":"Point"}
+}

--- a/data/171/311/816/5/1713118165.geojson
+++ b/data/171/311/816/5/1713118165.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118165,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-90.97835,30.25177,-90.97835,30.25177",
+    "geom:latitude":30.25177,
+    "geom:longitude":-90.97835,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"5.0",
+    "gn:asciiname":"Twin Lakes Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":9,
+    "gn:elevation":"4.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7708372,
+    "gn:latitude":30.25177,
+    "gn:longitude":-90.97835,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Twin Lakes Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-90.99835,30.23177,-90.95835,30.27177",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086687,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7708372
+    },
+    "wof:country":"US",
+    "wof:geomhash":"b06545a933903162acb8a7efa647ff70",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118165,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086687,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118165,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Twin Lakes Mobile Estates",
+    "wof:parent_id":102086687,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343787951
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -90.97835,
+    30.25177,
+    -90.97835,
+    30.25177
+],
+  "geometry": {"coordinates":[-90.97835000000001,30.25177],"type":"Point"}
+}

--- a/data/171/311/816/9/1713118169.geojson
+++ b/data/171/311/816/9/1713118169.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118169,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.54833,43.23056,-85.54833,43.23056",
+    "geom:latitude":43.23056,
+    "geom:longitude":-85.54833,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"81",
+    "gn:admin3_code":"14200.0",
+    "gn:asciiname":"Cedar Springs Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":259,
+    "gn:elevation":"263.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7252224,
+    "gn:latitude":43.23056,
+    "gn:longitude":-85.54833,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Cedar Springs Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-85.56833,43.21056,-85.52833,43.25056",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083023,
+        404509035,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7252224
+    },
+    "wof:country":"US",
+    "wof:geomhash":"0d0e785ce20b2a8d19fd4590391ef35d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118169,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083023,
+            "localadmin_id":404509035,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118169,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Cedar Springs Mobile Estates",
+    "wof:parent_id":404509035,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343374823
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.54833,
+    43.23056,
+    -85.54833,
+    43.23056
+],
+  "geometry": {"coordinates":[-85.54833000000001,43.23056],"type":"Point"}
+}

--- a/data/171/311/817/1/1713118171.geojson
+++ b/data/171/311/817/1/1713118171.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118171,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.1502,48.05203,-122.1502,48.05203",
+    "geom:latitude":48.05203,
+    "geom:longitude":-122.1502,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"61.0",
+    "gn:asciiname":"Glenwood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":17,
+    "gn:elevation":"17.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714232,
+    "gn:latitude":48.05203,
+    "gn:longitude":-122.1502,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Glenwood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.1702,48.03203,-122.1302,48.07203",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087537,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714232
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3d7e62391aa5a8f70e5348b9623c624b",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118171,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087537,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118171,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Glenwood Mobile Estates",
+    "wof:parent_id":102087537,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343374585
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.1502,
+    48.05203,
+    -122.1502,
+    48.05203
+],
+  "geometry": {"coordinates":[-122.1502,48.05203],"type":"Point"}
+}

--- a/data/171/311/817/3/1713118173.geojson
+++ b/data/171/311/817/3/1713118173.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118173,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-93.17749,30.15641,-93.17749,30.15641",
+    "geom:latitude":30.15641,
+    "geom:longitude":-93.17749,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"19.0",
+    "gn:asciiname":"Fairview Recreational Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":8,
+    "gn:elevation":"6.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7708277,
+    "gn:latitude":30.15641,
+    "gn:longitude":-93.17749,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Fairview Recreational Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-93.19749,30.13641,-93.15749,30.17641",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081035,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7708277
+    },
+    "wof:country":"US",
+    "wof:geomhash":"28749609eebd19342999490d22cc0e84",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118173,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081035,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118173,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Fairview Recreational Mobile Estates",
+    "wof:parent_id":102081035,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343277821
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -93.17749,
+    30.15641,
+    -93.17749,
+    30.15641
+],
+  "geometry": {"coordinates":[-93.17749000000001,30.15641],"type":"Point"}
+}

--- a/data/171/311/817/5/1713118175.geojson
+++ b/data/171/311/817/5/1713118175.geojson
@@ -1,0 +1,82 @@
+{
+  "id": 1713118175,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.68244,38.85818,-76.68244,38.85818",
+    "geom:latitude":38.85818,
+    "geom:longitude":-76.68244,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"3.0",
+    "gn:asciiname":"Maryland Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":14,
+    "gn:elevation":"16.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4361853,
+    "gn:latitude":38.85818,
+    "gn:longitude":-76.68244,
+    "gn:modification_date":"2010-02-19",
+    "gn:name":"Maryland Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.70244,38.83818,-76.66244,38.87818",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Maryland Mobile Estates"
+    ],
+    "name:und_x_variant":[
+        "Maryland Manor Trailer Park"
+    ],
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083469,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4361853
+    },
+    "wof:country":"US",
+    "wof:geomhash":"ae62dfb661121ffce4ff739daf7f89f4",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118175,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083469,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118175,
+    "wof:lastmodified":1588726980,
+    "wof:name":"Maryland Mobile Estates",
+    "wof:parent_id":102083469,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343678231
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.68244,
+    38.85818,
+    -76.68244,
+    38.85818
+],
+  "geometry": {"coordinates":[-76.68244,38.85818],"type":"Point"}
+}

--- a/data/171/311/817/7/1713118177.geojson
+++ b/data/171/311/817/7/1713118177.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118177,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-111.58185,33.41901,-111.58185,33.41901",
+    "geom:latitude":33.41901,
+    "geom:longitude":-111.58185,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"13.0",
+    "gn:asciiname":"El Dorado Mobile Estates Resort",
+    "gn:country_code":"US",
+    "gn:dem":500,
+    "gn:elevation":"500.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8483909,
+    "gn:latitude":33.41901,
+    "gn:longitude":-111.58185,
+    "gn:modification_date":"2013-03-08",
+    "gn:name":"El Dorado Mobile Estates Resort",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-111.60185,33.39901,-111.56185,33.43901",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087421,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8483909
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6ca49fdeb02445247d87c92aaec658fb",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118177,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087421,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118177,
+    "wof:lastmodified":1588726980,
+    "wof:name":"El Dorado Mobile Estates Resort",
+    "wof:parent_id":102087421,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1225861189
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -111.58185,
+    33.41901,
+    -111.58185,
+    33.41901
+],
+  "geometry": {"coordinates":[-111.58185,33.41901],"type":"Point"}
+}

--- a/data/171/311/817/9/1713118179.geojson
+++ b/data/171/311/817/9/1713118179.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118179,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.77583,41.75083,-80.77583,41.75083",
+    "geom:latitude":41.75083,
+    "geom:longitude":-80.77583,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"7",
+    "gn:admin3_code":"38514.0",
+    "gn:asciiname":"Jefferson Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":280,
+    "gn:elevation":"279.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7232707,
+    "gn:latitude":41.75083,
+    "gn:longitude":-80.77583,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Jefferson Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-80.79583,41.73083,-80.75583,41.77083",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083657,
+        404524713,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7232707
+    },
+    "wof:country":"US",
+    "wof:geomhash":"348868a7e937af940d49db2f99f05d00",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118179,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083657,
+            "localadmin_id":404524713,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118179,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Jefferson Mobile Estates",
+    "wof:parent_id":404524713,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226458243
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.77583,
+    41.75083,
+    -80.77583,
+    41.75083
+],
+  "geometry": {"coordinates":[-80.77583,41.75083],"type":"Point"}
+}

--- a/data/171/311/818/1/1713118181.geojson
+++ b/data/171/311/818/1/1713118181.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118181,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.63436,47.61089,-122.63436,47.61089",
+    "geom:latitude":47.61089,
+    "geom:longitude":-122.63436,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"35.0",
+    "gn:asciiname":"Camelot Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":95,
+    "gn:elevation":"92.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714027,
+    "gn:latitude":47.61089,
+    "gn:longitude":-122.63436,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Camelot Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.65436,47.59089,-122.61436,47.63089",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081243,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714027
+    },
+    "wof:country":"US",
+    "wof:geomhash":"87508569431356d511effaa663cd0622",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118181,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081243,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118181,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Camelot Mobile Estates",
+    "wof:parent_id":102081243,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226453371
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.63436,
+    47.61089,
+    -122.63436,
+    47.61089
+],
+  "geometry": {"coordinates":[-122.63436,47.61089],"type":"Point"}
+}

--- a/data/171/311/818/3/1713118183.geojson
+++ b/data/171/311/818/3/1713118183.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118183,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-87.42222,46.28056,-87.42222,46.28056",
+    "geom:latitude":46.28056,
+    "geom:longitude":-87.42222,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"103",
+    "gn:admin3_code":"29720.0",
+    "gn:asciiname":"Northernair Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":334,
+    "gn:elevation":"338.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7140654,
+    "gn:latitude":46.28056,
+    "gn:longitude":-87.42222,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Northernair Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-87.44222,46.26056,-87.40222,46.30056",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083039,
+        404508607,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7140654
+    },
+    "wof:country":"US",
+    "wof:geomhash":"30e7507c69a62774660243996c7cda24",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118183,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083039,
+            "localadmin_id":404508607,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118183,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Northernair Mobile Estates",
+    "wof:parent_id":404508607,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226565021
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -87.42222,
+    46.28056,
+    -87.42222,
+    46.28056
+],
+  "geometry": {"coordinates":[-87.42222,46.28056],"type":"Point"}
+}

--- a/data/171/311/818/7/1713118187.geojson
+++ b/data/171/311/818/7/1713118187.geojson
@@ -1,0 +1,77 @@
+{
+  "id": 1713118187,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-94.10857,41.85971,-94.10857,41.85971",
+    "geom:latitude":41.85971,
+    "geom:longitude":-94.10857,
+    "gn:admin1_code":"IA",
+    "gn:admin2_code":"49.0",
+    "gn:admin3_code":"93993.0",
+    "gn:asciiname":"Bar-Jac Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":301,
+    "gn:elevation":"303.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4847721,
+    "gn:latitude":41.85971,
+    "gn:longitude":-94.10857,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Bar-Jac Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-94.12857,41.83971,-94.08857,41.87971",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086525,
+        85688713
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4847721
+    },
+    "wof:country":"US",
+    "wof:geomhash":"70b252f532280eb011143963ce1871d5",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118187,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086525,
+            "locality_id":-1,
+            "region_id":85688713
+        }
+    ],
+    "wof:id":1713118187,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Bar-Jac Mobile Estates",
+    "wof:parent_id":102086525,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1360009839
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -94.10857,
+    41.85971,
+    -94.10857,
+    41.85971
+],
+  "geometry": {"coordinates":[-94.10857,41.85971],"type":"Point"}
+}

--- a/data/171/311/818/9/1713118189.geojson
+++ b/data/171/311/818/9/1713118189.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118189,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-87.61056,45.12972,-87.61056,45.12972",
+    "geom:latitude":45.12972,
+    "geom:longitude":-87.61056,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"109",
+    "gn:admin3_code":"53020.0",
+    "gn:asciiname":"Bayside Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":180,
+    "gn:elevation":"178.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7149850,
+    "gn:latitude":45.12972,
+    "gn:longitude":-87.61056,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Bayside Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-87.63056,45.10972,-87.59056,45.14972",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083089,
+        404508819,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7149850
+    },
+    "wof:country":"US",
+    "wof:geomhash":"015c6642a2ee07ed715184ad11e83425",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118189,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083089,
+            "localadmin_id":404508819,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118189,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Bayside Mobile Estates",
+    "wof:parent_id":404508819,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1260202917
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -87.61056,
+    45.12972,
+    -87.61056,
+    45.12972
+],
+  "geometry": {"coordinates":[-87.61056000000001,45.12972],"type":"Point"}
+}

--- a/data/171/311/819/1/1713118191.geojson
+++ b/data/171/311/819/1/1713118191.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118191,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-110.95421,32.15693,-110.95421,32.15693",
+    "geom:latitude":32.15693,
+    "geom:longitude":-110.95421,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"19.0",
+    "gn:asciiname":"Parklane Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":766,
+    "gn:elevation":"767.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7723092,
+    "gn:latitude":32.15693,
+    "gn:longitude":-110.95421,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Parklane Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-110.97421,32.13693,-110.93421,32.17693",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081135,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7723092
+    },
+    "wof:country":"US",
+    "wof:geomhash":"7f2959e6fe46e17bd65bd01b608e6954",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118191,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081135,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118191,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Parklane Mobile Estates",
+    "wof:parent_id":102081135,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1260301333
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -110.95421,
+    32.15693,
+    -110.95421,
+    32.15693
+],
+  "geometry": {"coordinates":[-110.95421,32.15693],"type":"Point"}
+}

--- a/data/171/311/819/3/1713118193.geojson
+++ b/data/171/311/819/3/1713118193.geojson
@@ -1,0 +1,77 @@
+{
+  "id": 1713118193,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-77.9328,35.3614,-77.9328,35.3614",
+    "geom:latitude":35.3614,
+    "geom:longitude":-77.9328,
+    "gn:admin1_code":"NC",
+    "gn:admin2_code":"191",
+    "gn:admin3_code":"92256.0",
+    "gn:asciiname":"Woodshire Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":31,
+    "gn:elevation":"35.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7230579,
+    "gn:latitude":35.3614,
+    "gn:longitude":-77.9328,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Woodshire Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-77.9528,35.3414,-77.9128,35.3814",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087601,
+        85688773
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7230579
+    },
+    "wof:country":"US",
+    "wof:geomhash":"55b37458af868a625f8f4ef3f4934cca",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118193,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087601,
+            "locality_id":-1,
+            "region_id":85688773
+        }
+    ],
+    "wof:id":1713118193,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Woodshire Mobile Estates",
+    "wof:parent_id":102087601,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1260301407
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -77.9328,
+    35.3614,
+    -77.9328,
+    35.3614
+],
+  "geometry": {"coordinates":[-77.9328,35.3614],"type":"Point"}
+}

--- a/data/171/311/819/5/1713118195.geojson
+++ b/data/171/311/819/5/1713118195.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118195,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.4004,47.15285,-122.4004,47.15285",
+    "geom:latitude":47.15285,
+    "geom:longitude":-122.4004,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"Franklin Pierce Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":126,
+    "gn:elevation":"129.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714420,
+    "gn:latitude":47.15285,
+    "gn:longitude":-122.4004,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Franklin Pierce Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.4204,47.13285,-122.3804,47.17285",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087547,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714420
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3d7575bf9590917dff15e84b40c39a21",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118195,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087547,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118195,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Franklin Pierce Mobile Estates",
+    "wof:parent_id":102087547,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1260115989
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.4004,
+    47.15285,
+    -122.4004,
+    47.15285
+],
+  "geometry": {"coordinates":[-122.4004,47.15285],"type":"Point"}
+}

--- a/data/171/311/819/7/1713118197.geojson
+++ b/data/171/311/819/7/1713118197.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118197,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.18814,47.75511,-122.18814,47.75511",
+    "geom:latitude":47.75511,
+    "geom:longitude":-122.18814,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"33.0",
+    "gn:asciiname":"Riverside Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":7,
+    "gn:elevation":"7.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714021,
+    "gn:latitude":47.75511,
+    "gn:longitude":-122.18814,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Riverside Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.20814,47.73511,-122.16814,47.77511",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086191,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714021
+    },
+    "wof:country":"US",
+    "wof:geomhash":"db55c64a350217c182884eec2fe4e473",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118197,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086191,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118197,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Riverside Mobile Estates",
+    "wof:parent_id":102086191,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1344080945
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.18814,
+    47.75511,
+    -122.18814,
+    47.75511
+],
+  "geometry": {"coordinates":[-122.18814,47.75511],"type":"Point"}
+}

--- a/data/171/311/819/9/1713118199.geojson
+++ b/data/171/311/819/9/1713118199.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118199,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.76567,28.93213,-81.76567,28.93213",
+    "geom:latitude":28.93213,
+    "geom:longitude":-81.76567,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"69.0",
+    "gn:asciiname":"Sunlake Estates Mobile Park",
+    "gn:country_code":"US",
+    "gn:dem":21,
+    "gn:elevation":"24.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7190690,
+    "gn:latitude":28.93213,
+    "gn:longitude":-81.76567,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Sunlake Estates Mobile Park",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.78567,28.91213,-81.74567,28.95213",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084775,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7190690
+    },
+    "wof:country":"US",
+    "wof:geomhash":"436e73cb54b33bc733e5d44ca968bb5c",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118199,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084775,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118199,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Sunlake Estates Mobile Park",
+    "wof:parent_id":102084775,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343478377
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.76567,
+    28.93213,
+    -81.76567,
+    28.93213
+],
+  "geometry": {"coordinates":[-81.76567,28.93213],"type":"Point"}
+}

--- a/data/171/311/820/1/1713118201.geojson
+++ b/data/171/311/820/1/1713118201.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118201,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-110.95453,32.28496,-110.95453,32.28496",
+    "geom:latitude":32.28496,
+    "geom:longitude":-110.95453,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"19.0",
+    "gn:asciiname":"Vista Del Norte Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":713,
+    "gn:elevation":"711.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7723083,
+    "gn:latitude":32.28496,
+    "gn:longitude":-110.95453,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Vista Del Norte Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-110.97453,32.26496,-110.93453,32.30496",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081135,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7723083
+    },
+    "wof:country":"US",
+    "wof:geomhash":"39e3cf2cc1d0f39119efeace32fdfc6f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118201,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081135,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118201,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Vista Del Norte Mobile Estates",
+    "wof:parent_id":102081135,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343598103
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -110.95453,
+    32.28496,
+    -110.95453,
+    32.28496
+],
+  "geometry": {"coordinates":[-110.95453000000001,32.28496],"type":"Point"}
+}

--- a/data/171/311/820/5/1713118205.geojson
+++ b/data/171/311/820/5/1713118205.geojson
@@ -1,0 +1,104 @@
+{
+  "id": 1713118205,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-121.14964,36.18136,-121.14964,36.18136",
+    "geom:latitude":36.18136,
+    "geom:longitude":-121.14964,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"Pine Canyon Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":124,
+    "gn:elevation":"117.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5382844,
+    "gn:latitude":36.18136,
+    "gn:longitude":-121.14964,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Pine Canyon Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-121.16964,36.16136,-121.12964,36.20136",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "name:azb_x_preferred":[
+        "\u067e\u0627\u06cc\u0646 \u06a9\u0627\u0646\u06cc\u0648\u0646"
+    ],
+    "name:ceb_x_preferred":[
+        "Pine Canyon Mobile Estates"
+    ],
+    "name:eus_x_preferred":[
+        "Pine Canyon"
+    ],
+    "name:fas_x_preferred":[
+        "\u067e\u0627\u06cc\u0646 \u06a9\u0627\u0646\u06cc\u0648\u0646"
+    ],
+    "name:hrv_x_preferred":[
+        "Pine Canyon"
+    ],
+    "name:mlg_x_preferred":[
+        "Pine Canyon"
+    ],
+    "name:pol_x_preferred":[
+        "Pine Canyon"
+    ],
+    "name:spa_x_preferred":[
+        "Pine Canyon"
+    ],
+    "name:srp_x_preferred":[
+        "\u041f\u0430\u0458\u043d \u041a\u0430\u043d\u0458\u043e\u043d"
+    ],
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102080859,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5382844,
+        "wk:page":"Pine_Canyon%2C_California"
+    },
+    "wof:country":"US",
+    "wof:geomhash":"a3a2144f5017931a08c028d55c515bb4",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118205,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102080859,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118205,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Pine Canyon Mobile Estates",
+    "wof:parent_id":102080859,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343580853
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -121.14964,
+    36.18136,
+    -121.14964,
+    36.18136
+],
+  "geometry": {"coordinates":[-121.14964000000001,36.18136],"type":"Point"}
+}

--- a/data/171/311/820/7/1713118207.geojson
+++ b/data/171/311/820/7/1713118207.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118207,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.1543,31.9948,-81.1543,31.9948",
+    "geom:latitude":31.9948,
+    "geom:longitude":-81.1543,
+    "gn:admin1_code":"GA",
+    "gn:admin2_code":"51",
+    "gn:asciiname":"Southside Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":22,
+    "gn:elevation":"12.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7228075,
+    "gn:latitude":31.9948,
+    "gn:longitude":-81.1543,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Southside Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.1743,31.9748,-81.1343,32.0148",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082337,
+        85688535
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7228075
+    },
+    "wof:country":"US",
+    "wof:geomhash":"9afd676d6657bd0ff46db09c67abba82",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118207,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082337,
+            "locality_id":-1,
+            "region_id":85688535
+        }
+    ],
+    "wof:id":1713118207,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Southside Mobile Estates",
+    "wof:parent_id":102082337,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343874207
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.1543,
+    31.9948,
+    -81.1543,
+    31.9948
+],
+  "geometry": {"coordinates":[-81.15430000000001,31.9948],"type":"Point"}
+}

--- a/data/171/311/820/9/1713118209.geojson
+++ b/data/171/311/820/9/1713118209.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118209,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-97.61799,38.85762,-97.61799,38.85762",
+    "geom:latitude":38.85762,
+    "geom:longitude":-97.61799,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"169.0",
+    "gn:admin3_code":"62700.0",
+    "gn:asciiname":"Del - Ray Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":379,
+    "gn:elevation":"374.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8122739,
+    "gn:latitude":38.85762,
+    "gn:longitude":-97.61799,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Del - Ray Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-97.63799,38.83762,-97.59799,38.87762",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083453,
+        404502927,
+        85688555
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8122739
+    },
+    "wof:country":"US",
+    "wof:geomhash":"c9e6f8f1a05d8a96464117973f550599",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118209,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083453,
+            "localadmin_id":404502927,
+            "locality_id":-1,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1713118209,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Del - Ray Mobile Estates",
+    "wof:parent_id":404502927,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1343787901
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -97.61799,
+    38.85762,
+    -97.61799,
+    38.85762
+],
+  "geometry": {"coordinates":[-97.61799000000001,38.85762],"type":"Point"}
+}

--- a/data/171/311/821/1/1713118211.geojson
+++ b/data/171/311/821/1/1713118211.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118211,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.15512,48.10226,-122.15512,48.10226",
+    "geom:latitude":48.10226,
+    "geom:longitude":-122.15512,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"61.0",
+    "gn:asciiname":"Country Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":27,
+    "gn:elevation":"26.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714228,
+    "gn:latitude":48.10226,
+    "gn:longitude":-122.15512,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Country Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.17512,48.08226,-122.13512,48.12226",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087537,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714228
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6e934f513f7789e9c13f161522a89741",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118211,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087537,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118211,
+    "wof:lastmodified":1588726981,
+    "wof:name":"Country Mobile Estates",
+    "wof:parent_id":102087537,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293414197
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.15512,
+    48.10226,
+    -122.15512,
+    48.10226
+],
+  "geometry": {"coordinates":[-122.15512,48.10226],"type":"Point"}
+}

--- a/data/171/311/821/3/1713118213.geojson
+++ b/data/171/311/821/3/1713118213.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118213,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.31225,47.05183,-122.31225,47.05183",
+    "geom:latitude":47.05183,
+    "geom:longitude":-122.31225,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"Shadow Pines Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":164,
+    "gn:elevation":"161.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714156,
+    "gn:latitude":47.05183,
+    "gn:longitude":-122.31225,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Shadow Pines Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.33225,47.03183,-122.29225,47.07183",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087547,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714156
+    },
+    "wof:country":"US",
+    "wof:geomhash":"d02d8e66ac1dbb87fb1af193947a7d03",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118213,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087547,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118213,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Shadow Pines Mobile Estates",
+    "wof:parent_id":102087547,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293525993
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.31225,
+    47.05183,
+    -122.31225,
+    47.05183
+],
+  "geometry": {"coordinates":[-122.31225000000001,47.05183],"type":"Point"}
+}

--- a/data/171/311/821/5/1713118215.geojson
+++ b/data/171/311/821/5/1713118215.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118215,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.5912,28.1423,-81.5912,28.1423",
+    "geom:latitude":28.1423,
+    "geom:longitude":-81.5912,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"105.0",
+    "gn:asciiname":"Davenport Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":39,
+    "gn:elevation":"38.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7190721,
+    "gn:latitude":28.1423,
+    "gn:longitude":-81.5912,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Davenport Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.6112,28.1223,-81.5712,28.1623",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085843,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7190721
+    },
+    "wof:country":"US",
+    "wof:geomhash":"9ff670735adc5dd3f99e22e7cb2c4c2c",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118215,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085843,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118215,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Davenport Mobile Estates",
+    "wof:parent_id":102085843,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293803517
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.5912,
+    28.1423,
+    -81.5912,
+    28.1423
+],
+  "geometry": {"coordinates":[-81.5912,28.1423],"type":"Point"}
+}

--- a/data/171/311/821/7/1713118217.geojson
+++ b/data/171/311/821/7/1713118217.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118217,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.6525,40.98,-80.6525,40.98",
+    "geom:latitude":40.98,
+    "geom:longitude":-80.6525,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"99",
+    "gn:admin3_code":"4668.0",
+    "gn:asciiname":"Beechwood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":348,
+    "gn:elevation":"349.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7234597,
+    "gn:latitude":40.98,
+    "gn:longitude":-80.6525,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Beechwood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-80.6725,40.96,-80.6325,41.0",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084799,
+        404526095,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7234597
+    },
+    "wof:country":"US",
+    "wof:geomhash":"5c125063d696544968ae21e2bcce1123",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118217,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084799,
+            "localadmin_id":404526095,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118217,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Beechwood Mobile Estates",
+    "wof:parent_id":404526095,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293308611
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.6525,
+    40.98,
+    -80.6525,
+    40.98
+],
+  "geometry": {"coordinates":[-80.6525,40.98],"type":"Point"}
+}

--- a/data/171/311/821/9/1713118219.geojson
+++ b/data/171/311/821/9/1713118219.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118219,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.9652,28.1554,-81.9652,28.1554",
+    "geom:latitude":28.1554,
+    "geom:longitude":-81.9652,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"105.0",
+    "gn:asciiname":"Kern Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":45,
+    "gn:elevation":"43.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7191511,
+    "gn:latitude":28.1554,
+    "gn:longitude":-81.9652,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Kern Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.9852,28.1354,-81.9452,28.1754",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085843,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7191511
+    },
+    "wof:country":"US",
+    "wof:geomhash":"2e534a8602ad25118020a0ce54af5f13",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118219,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085843,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118219,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Kern Mobile Estates",
+    "wof:parent_id":102085843,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293711775
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.9652,
+    28.1554,
+    -81.9652,
+    28.1554
+],
+  "geometry": {"coordinates":[-81.9652,28.1554],"type":"Point"}
+}

--- a/data/171/311/822/3/1713118223.geojson
+++ b/data/171/311/822/3/1713118223.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118223,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.28167,40.46694,-122.28167,40.46694",
+    "geom:latitude":40.46694,
+    "geom:longitude":-122.28167,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"89",
+    "gn:asciiname":"Riviera Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":127,
+    "gn:elevation":"125.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7232386,
+    "gn:latitude":40.46694,
+    "gn:longitude":-122.28167,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Riviera Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.30167,40.44694,-122.26167,40.48694",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083577,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7232386
+    },
+    "wof:country":"US",
+    "wof:geomhash":"158111c05efbab544eccb9f9c2e24b4e",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118223,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083577,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118223,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Riviera Mobile Estates",
+    "wof:parent_id":102083577,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1360309703
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.28167,
+    40.46694,
+    -122.28167,
+    40.46694
+],
+  "geometry": {"coordinates":[-122.28167000000001,40.46694],"type":"Point"}
+}

--- a/data/171/311/822/5/1713118225.geojson
+++ b/data/171/311/822/5/1713118225.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118225,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-95.37556,45.86111,-95.37556,45.86111",
+    "geom:latitude":45.86111,
+    "geom:longitude":-95.37556,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"41.0",
+    "gn:admin3_code":"928.0",
+    "gn:asciiname":"Mobile Park Estates",
+    "gn:country_code":"US",
+    "gn:dem":428,
+    "gn:elevation":"432.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5037935,
+    "gn:latitude":45.86111,
+    "gn:longitude":-95.37556,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Mobile Park Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-95.39556,45.84111,-95.35556,45.88111",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087127,
+        404513751,
+        85688727
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5037935
+    },
+    "wof:country":"US",
+    "wof:geomhash":"9048ccca4de3f794eea6119e4840eae3",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118225,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087127,
+            "localadmin_id":404513751,
+            "locality_id":-1,
+            "region_id":85688727
+        }
+    ],
+    "wof:id":1713118225,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Mobile Park Estates",
+    "wof:parent_id":404513751,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293808321
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -95.37556,
+    45.86111,
+    -95.37556,
+    45.86111
+],
+  "geometry": {"coordinates":[-95.37555999999999,45.86111],"type":"Point"}
+}

--- a/data/171/311/822/7/1713118227.geojson
+++ b/data/171/311/822/7/1713118227.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118227,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-83.36333,43.51194,-83.36333,43.51194",
+    "geom:latitude":43.51194,
+    "geom:longitude":-83.36333,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"157",
+    "gn:admin3_code":"1620.0",
+    "gn:asciiname":"Pinerest Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":213,
+    "gn:elevation":"212.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7247548,
+    "gn:latitude":43.51194,
+    "gn:longitude":-83.36333,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Pinerest Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-83.38333,43.49194,-83.34333,43.53194",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082989,
+        404508035,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7247548
+    },
+    "wof:country":"US",
+    "wof:geomhash":"25b3302fcfb179fae62b2f8b7ca98702",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118227,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082989,
+            "localadmin_id":404508035,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118227,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Pinerest Mobile Estates",
+    "wof:parent_id":404508035,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1292919287
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -83.36333,
+    43.51194,
+    -83.36333,
+    43.51194
+],
+  "geometry": {"coordinates":[-83.36333,43.51194],"type":"Point"}
+}

--- a/data/171/311/822/9/1713118229.geojson
+++ b/data/171/311/822/9/1713118229.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118229,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-121.08828,38.92601,-121.08828,38.92601",
+    "geom:latitude":38.92601,
+    "geom:longitude":-121.08828,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"61.0",
+    "gn:asciiname":"Auburn Hills Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":427,
+    "gn:elevation":"426.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5325229,
+    "gn:latitude":38.92601,
+    "gn:longitude":-121.08828,
+    "gn:modification_date":"2010-02-19",
+    "gn:name":"Auburn Hills Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-121.10828,38.90601,-121.06828,38.94601",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "name:spa_x_preferred":[
+        "Auburn Hills Mobile Estates"
+    ],
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102080863,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5325229
+    },
+    "wof:country":"US",
+    "wof:geomhash":"cf372fcc1846331169c57bfc59c75694",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118229,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102080863,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118229,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Auburn Hills Mobile Estates",
+    "wof:parent_id":102080863,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1292914249
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -121.08828,
+    38.92601,
+    -121.08828,
+    38.92601
+],
+  "geometry": {"coordinates":[-121.08828,38.92601],"type":"Point"}
+}

--- a/data/171/311/823/1/1713118231.geojson
+++ b/data/171/311/823/1/1713118231.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118231,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.84,40.54389,-82.84,40.54389",
+    "geom:latitude":40.54389,
+    "geom:longitude":-82.84,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"117",
+    "gn:admin3_code":"30128.0",
+    "gn:asciiname":"Mohawk Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":324,
+    "gn:elevation":"324.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7235129,
+    "gn:latitude":40.54389,
+    "gn:longitude":-82.84,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Mohawk Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.86,40.52389,-82.82,40.56389",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083749,
+        404527007,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7235129
+    },
+    "wof:country":"US",
+    "wof:geomhash":"08942209094b29257a25fd799c449934",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118231,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083749,
+            "localadmin_id":404527007,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118231,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Mohawk Mobile Estates",
+    "wof:parent_id":404527007,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293799547
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.84,
+    40.54389,
+    -82.84,
+    40.54389
+],
+  "geometry": {"coordinates":[-82.84,40.54389],"type":"Point"}
+}

--- a/data/171/311/823/3/1713118233.geojson
+++ b/data/171/311/823/3/1713118233.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118233,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.0544,32.0416,-81.0544,32.0416",
+    "geom:latitude":32.0416,
+    "geom:longitude":-81.0544,
+    "gn:admin1_code":"GA",
+    "gn:admin2_code":"51",
+    "gn:asciiname":"Thunderbolt Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":3,
+    "gn:elevation":"2.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7228078,
+    "gn:latitude":32.0416,
+    "gn:longitude":-81.0544,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Thunderbolt Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.0744,32.0216,-81.0344,32.0616",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082337,
+        85688535
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7228078
+    },
+    "wof:country":"US",
+    "wof:geomhash":"a05d28f97c80262d684d8cf2bd5d2e23",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118233,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082337,
+            "locality_id":-1,
+            "region_id":85688535
+        }
+    ],
+    "wof:id":1713118233,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Thunderbolt Mobile Estates",
+    "wof:parent_id":102082337,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293698037
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.0544,
+    32.0416,
+    -81.0544,
+    32.0416
+],
+  "geometry": {"coordinates":[-81.0544,32.0416],"type":"Point"}
+}

--- a/data/171/311/823/5/1713118235.geojson
+++ b/data/171/311/823/5/1713118235.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118235,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.42528,27.48719,-81.42528,27.48719",
+    "geom:latitude":27.48719,
+    "geom:longitude":-81.42528,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"55.0",
+    "gn:asciiname":"Sebring Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":43,
+    "gn:elevation":"39.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7193094,
+    "gn:latitude":27.48719,
+    "gn:longitude":-81.42528,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Sebring Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.44528,27.46719,-81.40528,27.50719",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085801,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7193094
+    },
+    "wof:country":"US",
+    "wof:geomhash":"1bf750850743ecea969c9146dfd14c44",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118235,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085801,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118235,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Sebring Mobile Estates",
+    "wof:parent_id":102085801,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1360301457
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.42528,
+    27.48719,
+    -81.42528,
+    27.48719
+],
+  "geometry": {"coordinates":[-81.42528,27.48719],"type":"Point"}
+}

--- a/data/171/311/823/7/1713118237.geojson
+++ b/data/171/311/823/7/1713118237.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118237,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.76333,37.34139,-76.76333,37.34139",
+    "geom:latitude":37.34139,
+    "geom:longitude":-76.76333,
+    "gn:admin1_code":"VA",
+    "gn:admin2_code":"95.0",
+    "gn:asciiname":"Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":35,
+    "gn:elevation":"31.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":6332174,
+    "gn:latitude":37.34139,
+    "gn:longitude":-76.76333,
+    "gn:modification_date":"2010-02-20",
+    "gn:name":"Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.78333,37.32139,-76.74333,37.36139",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085967,
+        85688747
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":6332174
+    },
+    "wof:country":"US",
+    "wof:geomhash":"c83379c39541aa822e3b67efbc8b369f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118237,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085967,
+            "locality_id":-1,
+            "region_id":85688747
+        }
+    ],
+    "wof:id":1713118237,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Mobile Estates",
+    "wof:parent_id":102085967,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1360309913
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.76333,
+    37.34139,
+    -76.76333,
+    37.34139
+],
+  "geometry": {"coordinates":[-76.76333,37.34139],"type":"Point"}
+}

--- a/data/171/311/824/1/1713118241.geojson
+++ b/data/171/311/824/1/1713118241.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118241,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-83.825,42.56667,-83.825,42.56667",
+    "geom:latitude":42.56667,
+    "geom:longitude":-83.825,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"93.0",
+    "gn:admin3_code":"31860.0",
+    "gn:asciiname":"Sylvan Glen Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":303,
+    "gn:elevation":"304.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7728911,
+    "gn:latitude":42.56667,
+    "gn:longitude":-83.825,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Sylvan Glen Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-83.845,42.54667,-83.805,42.58667",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083145,
+        404507289,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7728911
+    },
+    "wof:country":"US",
+    "wof:geomhash":"79c4542f4c74738208145e1c4065ea2d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118241,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083145,
+            "localadmin_id":404507289,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118241,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Sylvan Glen Mobile Estates",
+    "wof:parent_id":404507289,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293608639
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -83.825,
+    42.56667,
+    -83.825,
+    42.56667
+],
+  "geometry": {"coordinates":[-83.825,42.56667],"type":"Point"}
+}

--- a/data/171/311/824/3/1713118243.geojson
+++ b/data/171/311/824/3/1713118243.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118243,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.63639,43.08833,-85.63639,43.08833",
+    "geom:latitude":43.08833,
+    "geom:longitude":-85.63639,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"81",
+    "gn:admin3_code":"64660.0",
+    "gn:asciiname":"Northern Estates Mobile Village South",
+    "gn:country_code":"US",
+    "gn:dem":241,
+    "gn:elevation":"244.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7252491,
+    "gn:latitude":43.08833,
+    "gn:longitude":-85.63639,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Northern Estates Mobile Village South",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-85.65639,43.06833,-85.61639,43.10833",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083023,
+        404507861,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7252491
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6a305aec5e541c03b225fea9e5b55bb1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118243,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083023,
+            "localadmin_id":404507861,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118243,
+    "wof:lastmodified":1588726982,
+    "wof:name":"Northern Estates Mobile Village South",
+    "wof:parent_id":404507861,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1292928621
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.63639,
+    43.08833,
+    -85.63639,
+    43.08833
+],
+  "geometry": {"coordinates":[-85.63639000000001,43.08833],"type":"Point"}
+}

--- a/data/171/311/824/5/1713118245.geojson
+++ b/data/171/311/824/5/1713118245.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118245,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-83.40472,41.20222,-83.40472,41.20222",
+    "geom:latitude":41.20222,
+    "geom:longitude":-83.40472,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"147",
+    "gn:admin3_code":"38066.0",
+    "gn:asciiname":"Fostoria Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":225,
+    "gn:elevation":"226.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7248759,
+    "gn:latitude":41.20222,
+    "gn:longitude":-83.40472,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Fostoria Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-83.42472,41.18222,-83.38472,41.22222",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084717,
+        404525609,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7248759
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6da88eaabe7bc44bd82411b8434fe06b",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118245,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084717,
+            "localadmin_id":404525609,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118245,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Fostoria Mobile Estates",
+    "wof:parent_id":404525609,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293020335
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -83.40472,
+    41.20222,
+    -83.40472,
+    41.20222
+],
+  "geometry": {"coordinates":[-83.40472,41.20222],"type":"Point"}
+}

--- a/data/171/311/824/7/1713118247.geojson
+++ b/data/171/311/824/7/1713118247.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118247,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.14343,48.17669,-122.14343,48.17669",
+    "geom:latitude":48.17669,
+    "geom:longitude":-122.14343,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"61.0",
+    "gn:asciiname":"Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":38,
+    "gn:elevation":"40.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713965,
+    "gn:latitude":48.17669,
+    "gn:longitude":-122.14343,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.16343,48.15669,-122.12343,48.19669",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087537,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713965
+    },
+    "wof:country":"US",
+    "wof:geomhash":"9bb2effdcc40ab390859381675d3d3eb",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118247,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087537,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118247,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Mobile Estates",
+    "wof:parent_id":102087537,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293118303
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.14343,
+    48.17669,
+    -122.14343,
+    48.17669
+],
+  "geometry": {"coordinates":[-122.14343,48.17669],"type":"Point"}
+}

--- a/data/171/311/824/9/1713118249.geojson
+++ b/data/171/311/824/9/1713118249.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118249,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-73.84889,43.10222,-73.84889,43.10222",
+    "geom:latitude":43.10222,
+    "geom:longitude":-73.84889,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"91",
+    "gn:admin3_code":"30444.0",
+    "gn:asciiname":"Grange Road Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":177,
+    "gn:elevation":"174.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7225829,
+    "gn:latitude":43.10222,
+    "gn:longitude":-73.84889,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Grange Road Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-73.86889,43.08222,-73.82889,43.12222",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082413,
+        404523169,
+        85688543
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7225829
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6611e2b60f55b65e0f24ca973032971d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118249,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082413,
+            "localadmin_id":404523169,
+            "locality_id":-1,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1713118249,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Grange Road Mobile Estates",
+    "wof:parent_id":404523169,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293114939
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -73.84889,
+    43.10222,
+    -73.84889,
+    43.10222
+],
+  "geometry": {"coordinates":[-73.84889,43.10222],"type":"Point"}
+}

--- a/data/171/311/825/1/1713118251.geojson
+++ b/data/171/311/825/1/1713118251.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118251,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.1715,25.9788,-80.1715,25.9788",
+    "geom:latitude":25.9788,
+    "geom:longitude":-80.1715,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"11.0",
+    "gn:asciiname":"Holiday Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":8,
+    "gn:elevation":"1.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7190743,
+    "gn:latitude":25.9788,
+    "gn:longitude":-80.1715,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Holiday Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-80.1915,25.9588,-80.1515,25.9988",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084727,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7190743
+    },
+    "wof:country":"US",
+    "wof:geomhash":"903a3d412e1755c8ab61e4200ab066a3",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118251,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084727,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118251,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Holiday Mobile Estates",
+    "wof:parent_id":102084727,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293025301
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.1715,
+    25.9788,
+    -80.1715,
+    25.9788
+],
+  "geometry": {"coordinates":[-80.17149999999999,25.9788],"type":"Point"}
+}

--- a/data/171/311/825/3/1713118253.geojson
+++ b/data/171/311/825/3/1713118253.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118253,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-83.40556,43.48083,-83.40556,43.48083",
+    "geom:latitude":43.48083,
+    "geom:longitude":-83.40556,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"157",
+    "gn:admin3_code":"13420.0",
+    "gn:asciiname":"Caro Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":222,
+    "gn:elevation":"217.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7247547,
+    "gn:latitude":43.48083,
+    "gn:longitude":-83.40556,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Caro Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-83.42556,43.46083,-83.38556,43.50083",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082989,
+        404508125,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7247547
+    },
+    "wof:country":"US",
+    "wof:geomhash":"93751b32cc935880ddd3f7a2c7d02373",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118253,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082989,
+            "localadmin_id":404508125,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118253,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Caro Mobile Estates",
+    "wof:parent_id":404508125,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293329653
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -83.40556,
+    43.48083,
+    -83.40556,
+    43.48083
+],
+  "geometry": {"coordinates":[-83.40555999999999,43.48083],"type":"Point"}
+}

--- a/data/171/311/825/5/1713118255.geojson
+++ b/data/171/311/825/5/1713118255.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118255,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.46258,48.74043,-122.46258,48.74043",
+    "geom:latitude":48.74043,
+    "geom:longitude":-122.46258,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"73.0",
+    "gn:asciiname":"Lakeway Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":52,
+    "gn:elevation":"52.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713996,
+    "gn:latitude":48.74043,
+    "gn:longitude":-122.46258,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Lakeway Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.48258,48.72043,-122.44258,48.76043",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085363,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713996
+    },
+    "wof:country":"US",
+    "wof:geomhash":"4c9d512a820745278981f4ce76037ec8",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118255,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085363,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118255,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Lakeway Mobile Estates",
+    "wof:parent_id":102085363,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1293503521
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.46258,
+    48.74043,
+    -122.46258,
+    48.74043
+],
+  "geometry": {"coordinates":[-122.46258,48.74043],"type":"Point"}
+}

--- a/data/171/311/825/9/1713118259.geojson
+++ b/data/171/311/825/9/1713118259.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118259,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.63778,42.47222,-85.63778,42.47222",
+    "geom:latitude":42.47222,
+    "geom:longitude":-85.63778,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"5.0",
+    "gn:admin3_code":"35720.0",
+    "gn:asciiname":"Gun River Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":221,
+    "gn:elevation":"221.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7308768,
+    "gn:latitude":42.47222,
+    "gn:longitude":-85.63778,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Gun River Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-85.65778,42.45222,-85.61778,42.49222",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083043,
+        404506667,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7308768
+    },
+    "wof:country":"US",
+    "wof:geomhash":"44b50c611d2bd5532d21874f072947b2",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118259,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083043,
+            "localadmin_id":404506667,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118259,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Gun River Mobile Estates",
+    "wof:parent_id":404506667,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242981757
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.63778,
+    42.47222,
+    -85.63778,
+    42.47222
+],
+  "geometry": {"coordinates":[-85.63778000000001,42.47222],"type":"Point"}
+}

--- a/data/171/311/826/1/1713118261.geojson
+++ b/data/171/311/826/1/1713118261.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118261,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-92.06414,30.26638,-92.06414,30.26638",
+    "geom:latitude":30.26638,
+    "geom:longitude":-92.06414,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"55.0",
+    "gn:asciiname":"Cypress Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":15,
+    "gn:elevation":"12.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7708258,
+    "gn:latitude":30.26638,
+    "gn:longitude":-92.06414,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Cypress Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-92.08414,30.24638,-92.04414,30.28638",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081919,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7708258
+    },
+    "wof:country":"US",
+    "wof:geomhash":"887f3e424dddd47f9fcdcf4c7f2a3b5a",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118261,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081919,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118261,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Cypress Mobile Estates",
+    "wof:parent_id":102081919,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243279695
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -92.06414,
+    30.26638,
+    -92.06414,
+    30.26638
+],
+  "geometry": {"coordinates":[-92.06413999999999,30.26638],"type":"Point"}
+}

--- a/data/171/311/826/3/1713118263.geojson
+++ b/data/171/311/826/3/1713118263.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118263,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.9797,29.1159,-80.9797,29.1159",
+    "geom:latitude":29.1159,
+    "geom:longitude":-80.9797,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"127.0",
+    "gn:asciiname":"Briarwood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":6,
+    "gn:elevation":"3.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7192805,
+    "gn:latitude":29.1159,
+    "gn:longitude":-80.9797,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Briarwood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-80.9997,29.0959,-80.9597,29.1359",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085865,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7192805
+    },
+    "wof:country":"US",
+    "wof:geomhash":"349d7d2828861ac0aa0e00247614767f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118263,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085865,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118263,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Briarwood Mobile Estates",
+    "wof:parent_id":102085865,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243379271
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.9797,
+    29.1159,
+    -80.9797,
+    29.1159
+],
+  "geometry": {"coordinates":[-80.97969999999999,29.1159],"type":"Point"}
+}

--- a/data/171/311/826/5/1713118265.geojson
+++ b/data/171/311/826/5/1713118265.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118265,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-92.08949,30.23689,-92.08949,30.23689",
+    "geom:latitude":30.23689,
+    "geom:longitude":-92.08949,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"55.0",
+    "gn:asciiname":"Shorts Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":14,
+    "gn:elevation":"10.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7708335,
+    "gn:latitude":30.23689,
+    "gn:longitude":-92.08949,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Shorts Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-92.10949,30.21689,-92.06949,30.25689",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081919,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7708335
+    },
+    "wof:country":"US",
+    "wof:geomhash":"805d276ba94a303fc8ba7245aba1f411",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118265,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081919,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118265,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Shorts Mobile Estates",
+    "wof:parent_id":102081919,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242693841
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -92.08949,
+    30.23689,
+    -92.08949,
+    30.23689
+],
+  "geometry": {"coordinates":[-92.08949,30.23689],"type":"Point"}
+}

--- a/data/171/311/826/7/1713118267.geojson
+++ b/data/171/311/826/7/1713118267.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118267,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.35283,47.02186,-122.35283,47.02186",
+    "geom:latitude":47.02186,
+    "geom:longitude":-122.35283,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"Parklane Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":147,
+    "gn:elevation":"148.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714155,
+    "gn:latitude":47.02186,
+    "gn:longitude":-122.35283,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Parklane Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.37283,47.00186,-122.33283,47.04186",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087547,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714155
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6bf01b1f16c32016d72c96c9f5ffc9c2",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118267,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087547,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118267,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Parklane Mobile Estates",
+    "wof:parent_id":102087547,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242588989
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.35283,
+    47.02186,
+    -122.35283,
+    47.02186
+],
+  "geometry": {"coordinates":[-122.35283,47.02186],"type":"Point"}
+}

--- a/data/171/311/826/9/1713118269.geojson
+++ b/data/171/311/826/9/1713118269.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118269,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-92.81827,30.53195,-92.81827,30.53195",
+    "geom:latitude":30.53195,
+    "geom:longitude":-92.81827,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"3.0",
+    "gn:asciiname":"Grandview Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":19,
+    "gn:elevation":"16.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7707962,
+    "gn:latitude":30.53195,
+    "gn:longitude":-92.81827,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Grandview Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-92.83827,30.51195,-92.79827,30.55195",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086679,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7707962
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3d63284cbf66f866b79929f18a80314e",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118269,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086679,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118269,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Grandview Mobile Estates",
+    "wof:parent_id":102086679,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242588561
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -92.81827,
+    30.53195,
+    -92.81827,
+    30.53195
+],
+  "geometry": {"coordinates":[-92.81827,30.53195],"type":"Point"}
+}

--- a/data/171/311/827/1/1713118271.geojson
+++ b/data/171/311/827/1/1713118271.geojson
@@ -1,0 +1,82 @@
+{
+  "id": 1713118271,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.69476,38.81574,-76.69476,38.81574",
+    "geom:latitude":38.81574,
+    "geom:longitude":-76.69476,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"3.0",
+    "gn:asciiname":"Patuxent Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":17,
+    "gn:elevation":"17.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4365061,
+    "gn:latitude":38.81574,
+    "gn:longitude":-76.69476,
+    "gn:modification_date":"2010-02-19",
+    "gn:name":"Patuxent Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.71476,38.79574,-76.67476,38.83574",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Patuxent Mobile Estates"
+    ],
+    "name:und_x_variant":[
+        "Patuxent Mobile Homes"
+    ],
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083469,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4365061
+    },
+    "wof:country":"US",
+    "wof:geomhash":"964c8b896246adc3e35da014bb391182",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118271,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083469,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118271,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Patuxent Mobile Estates",
+    "wof:parent_id":102083469,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242995713
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.69476,
+    38.81574,
+    -76.69476,
+    38.81574
+],
+  "geometry": {"coordinates":[-76.69476,38.81574],"type":"Point"}
+}

--- a/data/171/311/827/3/1713118273.geojson
+++ b/data/171/311/827/3/1713118273.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118273,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-112.16182,33.53615,-112.16182,33.53615",
+    "geom:latitude":33.53615,
+    "geom:longitude":-112.16182,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"13.0",
+    "gn:asciiname":"Blue Sky Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":354,
+    "gn:elevation":"355.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5286194,
+    "gn:latitude":33.53615,
+    "gn:longitude":-112.16182,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Blue Sky Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-112.18182,33.51615,-112.14182,33.55615",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087421,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5286194
+    },
+    "wof:country":"US",
+    "wof:geomhash":"8d662832609d9684d70cd58f177d4969",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118273,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087421,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118273,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Blue Sky Mobile Estates",
+    "wof:parent_id":102087421,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243191979
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -112.16182,
+    33.53615,
+    -112.16182,
+    33.53615
+],
+  "geometry": {"coordinates":[-112.16182000000001,33.53615],"type":"Point"}
+}

--- a/data/171/311/827/7/1713118277.geojson
+++ b/data/171/311/827/7/1713118277.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118277,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.67691,38.80706,-76.67691,38.80706",
+    "geom:latitude":38.80706,
+    "geom:longitude":-76.67691,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"3.0",
+    "gn:asciiname":"Boones Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":35,
+    "gn:elevation":"29.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4349105,
+    "gn:latitude":38.80706,
+    "gn:longitude":-76.67691,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Boones Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.69691,38.78706,-76.65691,38.82706",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083469,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4349105
+    },
+    "wof:country":"US",
+    "wof:geomhash":"943557c06cf3b68a7929b2ebeecc4579",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118277,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083469,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118277,
+    "wof:lastmodified":1588726983,
+    "wof:name":"Boones Mobile Estates",
+    "wof:parent_id":102083469,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243565733
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.67691,
+    38.80706,
+    -76.67691,
+    38.80706
+],
+  "geometry": {"coordinates":[-76.67691000000001,38.80706],"type":"Point"}
+}

--- a/data/171/311/827/9/1713118279.geojson
+++ b/data/171/311/827/9/1713118279.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118279,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-73.87056,41.97861,-73.87056,41.97861",
+    "geom:latitude":41.97861,
+    "geom:longitude":-73.87056,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"27.0",
+    "gn:admin3_code":"60905.0",
+    "gn:asciiname":"Mountain View Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":82,
+    "gn:elevation":"83.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7199911,
+    "gn:latitude":41.97861,
+    "gn:longitude":-73.87056,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Mountain View Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-73.89056,41.95861,-73.85056,41.99861",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082363,
+        404522311,
+        85688543
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7199911
+    },
+    "wof:country":"US",
+    "wof:geomhash":"c53465cedc15a74bb995c744edcedfd7",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118279,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082363,
+            "localadmin_id":404522311,
+            "locality_id":-1,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1713118279,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Mountain View Mobile Estates",
+    "wof:parent_id":404522311,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242987135
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -73.87056,
+    41.97861,
+    -73.87056,
+    41.97861
+],
+  "geometry": {"coordinates":[-73.87056,41.97861],"type":"Point"}
+}

--- a/data/171/311/828/1/1713118281.geojson
+++ b/data/171/311/828/1/1713118281.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118281,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.4489,27.4658,-81.4489,27.4658",
+    "geom:latitude":27.4658,
+    "geom:longitude":-81.4489,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"55.0",
+    "gn:asciiname":"Jackson Creek Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":36,
+    "gn:elevation":"31.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7193089,
+    "gn:latitude":27.4658,
+    "gn:longitude":-81.4489,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Jackson Creek Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.4689,27.4458,-81.4289,27.4858",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085801,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7193089
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6796945ab780d8ac0602152d475ad23f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118281,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085801,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118281,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Jackson Creek Mobile Estates",
+    "wof:parent_id":102085801,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243382777
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.4489,
+    27.4658,
+    -81.4489,
+    27.4658
+],
+  "geometry": {"coordinates":[-81.44889999999999,27.4658],"type":"Point"}
+}

--- a/data/171/311/828/3/1713118283.geojson
+++ b/data/171/311/828/3/1713118283.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118283,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-111.09523,45.71937,-111.09523,45.71937",
+    "geom:latitude":45.71937,
+    "geom:longitude":-111.09523,
+    "gn:admin1_code":"MT",
+    "gn:admin2_code":"31.0",
+    "gn:asciiname":"Hidden Valley Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":1413,
+    "gn:elevation":"1414.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5657250,
+    "gn:latitude":45.71937,
+    "gn:longitude":-111.09523,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Hidden Valley Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Denver",
+    "iso:country":"US",
+    "lbl:bbox":"-111.11523,45.69937,-111.07523,45.73937",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085133,
+        85688617
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5657250
+    },
+    "wof:country":"US",
+    "wof:geomhash":"5e72439e902acc90c5377ec13c359382",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118283,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085133,
+            "locality_id":-1,
+            "region_id":85688617
+        }
+    ],
+    "wof:id":1713118283,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Hidden Valley Mobile Estates",
+    "wof:parent_id":102085133,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1242794089
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -111.09523,
+    45.71937,
+    -111.09523,
+    45.71937
+],
+  "geometry": {"coordinates":[-111.09523,45.71937],"type":"Point"}
+}

--- a/data/171/311/828/5/1713118285.geojson
+++ b/data/171/311/828/5/1713118285.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118285,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-111.58347,33.42088,-111.58347,33.42088",
+    "geom:latitude":33.42088,
+    "geom:longitude":-111.58347,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"13.0",
+    "gn:asciiname":"Coral Sands Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":500,
+    "gn:elevation":"502.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5290841,
+    "gn:latitude":33.42088,
+    "gn:longitude":-111.58347,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Coral Sands Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-111.60347,33.40088,-111.56347,33.44088",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087421,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5290841
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6bb35aaecc9f8fd34320adf0a7a5c25d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118285,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087421,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118285,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Coral Sands Mobile Estates",
+    "wof:parent_id":102087421,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243470791
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -111.58347,
+    33.42088,
+    -111.58347,
+    33.42088
+],
+  "geometry": {"coordinates":[-111.58347000000001,33.42088],"type":"Point"}
+}

--- a/data/171/311/828/7/1713118287.geojson
+++ b/data/171/311/828/7/1713118287.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118287,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.39548,28.48511,-81.39548,28.48511",
+    "geom:latitude":28.48511,
+    "geom:longitude":-81.39548,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"95.0",
+    "gn:asciiname":"Wheel Estates Mobile Manor",
+    "gn:country_code":"US",
+    "gn:dem":30,
+    "gn:elevation":"29.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7192468,
+    "gn:latitude":28.48511,
+    "gn:longitude":-81.39548,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Wheel Estates Mobile Manor",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.41548,28.46511,-81.37548,28.50511",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085847,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7192468
+    },
+    "wof:country":"US",
+    "wof:geomhash":"fbb03074d4c085f50bcef143fab0ecd5",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118287,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085847,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118287,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Wheel Estates Mobile Manor",
+    "wof:parent_id":102085847,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1243465639
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.39548,
+    28.48511,
+    -81.39548,
+    28.48511
+],
+  "geometry": {"coordinates":[-81.39548000000001,28.48511],"type":"Point"}
+}

--- a/data/171/311/828/9/1713118289.geojson
+++ b/data/171/311/828/9/1713118289.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118289,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-93.12584,30.21144,-93.12584,30.21144",
+    "geom:latitude":30.21144,
+    "geom:longitude":-93.12584,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"19.0",
+    "gn:asciiname":"Chardele Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":7,
+    "gn:elevation":"5.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7708225,
+    "gn:latitude":30.21144,
+    "gn:longitude":-93.12584,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Chardele Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-93.14584,30.19144,-93.10584,30.23144",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081035,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7708225
+    },
+    "wof:country":"US",
+    "wof:geomhash":"313268c9ca4bb90e2143ad83f005b630",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118289,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081035,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118289,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Chardele Mobile Estates",
+    "wof:parent_id":102081035,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226168663
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -93.12584,
+    30.21144,
+    -93.12584,
+    30.21144
+],
+  "geometry": {"coordinates":[-93.12584,30.21144],"type":"Point"}
+}

--- a/data/171/311/829/1/1713118291.geojson
+++ b/data/171/311/829/1/1713118291.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118291,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-110.90657,32.26252,-110.90657,32.26252",
+    "geom:latitude":32.26252,
+    "geom:longitude":-110.90657,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"19.0",
+    "gn:asciiname":"Paradise Village Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":736,
+    "gn:elevation":"737.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7723084,
+    "gn:latitude":32.26252,
+    "gn:longitude":-110.90657,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Paradise Village Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-110.92657,32.24252,-110.88657,32.28252",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081135,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7723084
+    },
+    "wof:country":"US",
+    "wof:geomhash":"37d82a26c7820e856c5aaaf103d0d6ef",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118291,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081135,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118291,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Paradise Village Mobile Estates",
+    "wof:parent_id":102081135,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226167095
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -110.90657,
+    32.26252,
+    -110.90657,
+    32.26252
+],
+  "geometry": {"coordinates":[-110.90657,32.26252],"type":"Point"}
+}

--- a/data/171/311/829/5/1713118295.geojson
+++ b/data/171/311/829/5/1713118295.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118295,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-86.15056,43.2125,-86.15056,43.2125",
+    "geom:latitude":43.2125,
+    "geom:longitude":-86.15056,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"121",
+    "gn:admin3_code":"56340.0",
+    "gn:asciiname":"Arlington Estates Mobile Village",
+    "gn:country_code":"US",
+    "gn:dem":202,
+    "gn:elevation":"198.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7306763,
+    "gn:latitude":43.2125,
+    "gn:longitude":-86.15056,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Arlington Estates Mobile Village",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-86.17056,43.1925,-86.13056,43.2325",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083707,
+        404507977,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7306763
+    },
+    "wof:country":"US",
+    "wof:geomhash":"148363243bdf6b375c4b22c6dbd3cd4a",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118295,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083707,
+            "localadmin_id":404507977,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118295,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Arlington Estates Mobile Village",
+    "wof:parent_id":404507977,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226262307
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -86.15056,
+    43.2125,
+    -86.15056,
+    43.2125
+],
+  "geometry": {"coordinates":[-86.15056,43.2125],"type":"Point"}
+}

--- a/data/171/311/829/7/1713118297.geojson
+++ b/data/171/311/829/7/1713118297.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118297,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-86.20694,41.82361,-86.20694,41.82361",
+    "geom:latitude":41.82361,
+    "geom:longitude":-86.20694,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"27",
+    "gn:admin3_code":"39480.0",
+    "gn:asciiname":"Niles Pines Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":234,
+    "gn:elevation":"234.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7169196,
+    "gn:latitude":41.82361,
+    "gn:longitude":-86.20694,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Niles Pines Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-86.22694,41.80361,-86.18694,41.84361",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083027,
+        404507089,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7169196
+    },
+    "wof:country":"US",
+    "wof:geomhash":"ae013742e56b6a0fb73b41b8f778cb3e",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118297,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083027,
+            "localadmin_id":404507089,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118297,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Niles Pines Mobile Estates",
+    "wof:parent_id":404507089,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226262515
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -86.20694,
+    41.82361,
+    -86.20694,
+    41.82361
+],
+  "geometry": {"coordinates":[-86.20694,41.82361],"type":"Point"}
+}

--- a/data/171/311/829/9/1713118299.geojson
+++ b/data/171/311/829/9/1713118299.geojson
@@ -1,0 +1,77 @@
+{
+  "id": 1713118299,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.7841,34.7004,-76.7841,34.7004",
+    "geom:latitude":34.7004,
+    "geom:longitude":-76.7841,
+    "gn:admin1_code":"NC",
+    "gn:admin2_code":"31",
+    "gn:admin3_code":"92120.0",
+    "gn:asciiname":"Coastal Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":-1,
+    "gn:elevation":"2.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7230315,
+    "gn:latitude":34.7004,
+    "gn:longitude":-76.7841,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Coastal Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.8041,34.6804,-76.7641,34.7204",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102080875,
+        85688773
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7230315
+    },
+    "wof:country":"US",
+    "wof:geomhash":"86d0a748915929ab064576e7bd725aa6",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118299,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102080875,
+            "locality_id":-1,
+            "region_id":85688773
+        }
+    ],
+    "wof:id":1713118299,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Coastal Mobile Estates",
+    "wof:parent_id":102080875,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276568565
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.7841,
+    34.7004,
+    -76.7841,
+    34.7004
+],
+  "geometry": {"coordinates":[-76.7841,34.7004],"type":"Point"}
+}

--- a/data/171/311/830/1/1713118301.geojson
+++ b/data/171/311/830/1/1713118301.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118301,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.29005,47.16505,-122.29005,47.16505",
+    "geom:latitude":47.16505,
+    "geom:longitude":-122.29005,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"Meridian Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":126,
+    "gn:elevation":"122.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713254,
+    "gn:latitude":47.16505,
+    "gn:longitude":-122.29005,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Meridian Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.31005,47.14505,-122.27005,47.18505",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087547,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713254
+    },
+    "wof:country":"US",
+    "wof:geomhash":"b6c0bbf1658d224d8e90f1267e822e6f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118301,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087547,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118301,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Meridian Mobile Estates",
+    "wof:parent_id":102087547,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276589261
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.29005,
+    47.16505,
+    -122.29005,
+    47.16505
+],
+  "geometry": {"coordinates":[-122.29004999999999,47.16505],"type":"Point"}
+}

--- a/data/171/311/830/3/1713118303.geojson
+++ b/data/171/311/830/3/1713118303.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118303,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-90.32333,32.32194,-90.32333,32.32194",
+    "geom:latitude":32.32194,
+    "geom:longitude":-90.32333,
+    "gn:admin1_code":"MS",
+    "gn:admin2_code":"49",
+    "gn:asciiname":"Springridge Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":97,
+    "gn:elevation":"97.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7234587,
+    "gn:latitude":32.32194,
+    "gn:longitude":-90.32333,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Springridge Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-90.34333,32.30194,-90.30333,32.34194",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081407,
+        85688579
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7234587
+    },
+    "wof:country":"US",
+    "wof:geomhash":"8129ac01b9360b8a4297d17a1d84b029",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118303,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081407,
+            "locality_id":-1,
+            "region_id":85688579
+        }
+    ],
+    "wof:id":1713118303,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Springridge Mobile Estates",
+    "wof:parent_id":102081407,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276889423
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -90.32333,
+    32.32194,
+    -90.32333,
+    32.32194
+],
+  "geometry": {"coordinates":[-90.32333,32.32194],"type":"Point"}
+}

--- a/data/171/311/830/5/1713118305.geojson
+++ b/data/171/311/830/5/1713118305.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118305,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.7819,32.4149,-81.7819,32.4149",
+    "geom:latitude":32.4149,
+    "geom:longitude":-81.7819,
+    "gn:admin1_code":"GA",
+    "gn:admin2_code":"31",
+    "gn:asciiname":"Woodland Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":69,
+    "gn:elevation":"67.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7228084,
+    "gn:latitude":32.4149,
+    "gn:longitude":-81.7819,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Woodland Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.8019,32.3949,-81.7619,32.4349",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084405,
+        85688535
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7228084
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f75c77152decd403ae253d169ad074c1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118305,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084405,
+            "locality_id":-1,
+            "region_id":85688535
+        }
+    ],
+    "wof:id":1713118305,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Woodland Mobile Estates",
+    "wof:parent_id":102084405,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276355645
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.7819,
+    32.4149,
+    -81.7819,
+    32.4149
+],
+  "geometry": {"coordinates":[-81.78189999999999,32.4149],"type":"Point"}
+}

--- a/data/171/311/830/7/1713118307.geojson
+++ b/data/171/311/830/7/1713118307.geojson
@@ -1,0 +1,77 @@
+{
+  "id": 1713118307,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-78.1397,35.5804,-78.1397,35.5804",
+    "geom:latitude":35.5804,
+    "geom:longitude":-78.1397,
+    "gn:admin1_code":"NC",
+    "gn:admin2_code":"101",
+    "gn:admin3_code":"90256.0",
+    "gn:asciiname":"Country Squire Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":63,
+    "gn:elevation":"60.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7230326,
+    "gn:latitude":35.5804,
+    "gn:longitude":-78.1397,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Country Squire Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-78.1597,35.5604,-78.1197,35.6004",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102080883,
+        85688773
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7230326
+    },
+    "wof:country":"US",
+    "wof:geomhash":"c7c5318a635c673b9d5337ae91159f4f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118307,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102080883,
+            "locality_id":-1,
+            "region_id":85688773
+        }
+    ],
+    "wof:id":1713118307,
+    "wof:lastmodified":1588726984,
+    "wof:name":"Country Squire Mobile Estates",
+    "wof:parent_id":102080883,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276355785
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -78.1397,
+    35.5804,
+    -78.1397,
+    35.5804
+],
+  "geometry": {"coordinates":[-78.1397,35.5804],"type":"Point"}
+}

--- a/data/171/311/830/9/1713118309.geojson
+++ b/data/171/311/830/9/1713118309.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118309,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.22505,47.40469,-122.22505,47.40469",
+    "geom:latitude":47.40469,
+    "geom:longitude":-122.22505,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"33.0",
+    "gn:asciiname":"Willo Vista Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":8,
+    "gn:elevation":"15.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714184,
+    "gn:latitude":47.40469,
+    "gn:longitude":-122.22505,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Willo Vista Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.24505,47.38469,-122.20505,47.42469",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086191,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714184
+    },
+    "wof:country":"US",
+    "wof:geomhash":"cea4bda06d71ec557d86dc70b2e7af59",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118309,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086191,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118309,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Willo Vista Mobile Estates",
+    "wof:parent_id":102086191,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276479257
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.22505,
+    47.40469,
+    -122.22505,
+    47.40469
+],
+  "geometry": {"coordinates":[-122.22505,47.40469],"type":"Point"}
+}

--- a/data/171/311/831/3/1713118313.geojson
+++ b/data/171/311/831/3/1713118313.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118313,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-92.1925,46.825,-92.1925,46.825",
+    "geom:latitude":46.825,
+    "geom:longitude":-92.1925,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"137",
+    "gn:admin3_code":"28682.0",
+    "gn:asciiname":"Birchwood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":429,
+    "gn:elevation":"429.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7129103,
+    "gn:latitude":46.825,
+    "gn:longitude":-92.1925,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Birchwood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-92.2125,46.805,-92.1725,46.845",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087653,
+        404513281,
+        85688727
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7129103
+    },
+    "wof:country":"US",
+    "wof:geomhash":"84ebcdcc0b79be9ef2bdc1fbcab8fce5",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118313,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087653,
+            "localadmin_id":404513281,
+            "locality_id":-1,
+            "region_id":85688727
+        }
+    ],
+    "wof:id":1713118313,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Birchwood Mobile Estates",
+    "wof:parent_id":404513281,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276356031
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -92.1925,
+    46.825,
+    -92.1925,
+    46.825
+],
+  "geometry": {"coordinates":[-92.1925,46.825],"type":"Point"}
+}

--- a/data/171/311/831/5/1713118315.geojson
+++ b/data/171/311/831/5/1713118315.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118315,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.40639,40.98667,-81.40639,40.98667",
+    "geom:latitude":40.98667,
+    "geom:longitude":-81.40639,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"151",
+    "gn:admin3_code":"41314.0",
+    "gn:asciiname":"Maces Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":341,
+    "gn:elevation":"340.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7247501,
+    "gn:latitude":40.98667,
+    "gn:longitude":-81.40639,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Maces Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.42639,40.96667,-81.38639,41.00667",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083731,
+        404525793,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7247501
+    },
+    "wof:country":"US",
+    "wof:geomhash":"7206009c46605be75a0d1dce53c4504e",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118315,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083731,
+            "localadmin_id":404525793,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118315,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Maces Mobile Estates",
+    "wof:parent_id":404525793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276358945
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.40639,
+    40.98667,
+    -81.40639,
+    40.98667
+],
+  "geometry": {"coordinates":[-81.40639,40.98667],"type":"Point"}
+}

--- a/data/171/311/831/7/1713118317.geojson
+++ b/data/171/311/831/7/1713118317.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118317,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.99092,29.11937,-80.99092,29.11937",
+    "geom:latitude":29.11937,
+    "geom:longitude":-80.99092,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"127.0",
+    "gn:asciiname":"Maplewood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":7,
+    "gn:elevation":"1.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7192801,
+    "gn:latitude":29.11937,
+    "gn:longitude":-80.99092,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Maplewood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.01092,29.09937,-80.97092,29.13937",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085865,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7192801
+    },
+    "wof:country":"US",
+    "wof:geomhash":"70a8f2ae428be04c67477681ef416eb4",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118317,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085865,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118317,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Maplewood Mobile Estates",
+    "wof:parent_id":102085865,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276253713
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.99092,
+    29.11937,
+    -80.99092,
+    29.11937
+],
+  "geometry": {"coordinates":[-80.99092,29.11937],"type":"Point"}
+}

--- a/data/171/311/831/9/1713118319.geojson
+++ b/data/171/311/831/9/1713118319.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118319,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-117.05781,33.2342,-117.05781,33.2342",
+    "geom:latitude":33.2342,
+    "geom:longitude":-117.05781,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"73",
+    "gn:asciiname":"Hideaway Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":404,
+    "gn:elevation":"404.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5356783,
+    "gn:latitude":33.2342,
+    "gn:longitude":-117.05781,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Hideaway Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-117.07781,33.2142,-117.03781,33.2542",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083569,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5356783
+    },
+    "wof:country":"US",
+    "wof:geomhash":"82aa6c6b2521370cb48dff223de2d0d6",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118319,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083569,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118319,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Hideaway Mobile Estates",
+    "wof:parent_id":102083569,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226058703
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -117.05781,
+    33.2342,
+    -117.05781,
+    33.2342
+],
+  "geometry": {"coordinates":[-117.05781,33.2342],"type":"Point"}
+}

--- a/data/171/311/832/1/1713118321.geojson
+++ b/data/171/311/832/1/1713118321.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118321,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-114.53468,33.6078,-114.53468,33.6078",
+    "geom:latitude":33.6078,
+    "geom:longitude":-114.53468,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"65.0",
+    "gn:asciiname":"Blythe Marina Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":84,
+    "gn:elevation":"80.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5329655,
+    "gn:latitude":33.6078,
+    "gn:longitude":-114.53468,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Blythe Marina Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-114.55468,33.5878,-114.51468,33.6278",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086221,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5329655
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f32545afbcf7e39b1348a18cbdd38ac1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118321,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086221,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118321,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Blythe Marina Mobile Estates",
+    "wof:parent_id":102086221,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226763407
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -114.53468,
+    33.6078,
+    -114.53468,
+    33.6078
+],
+  "geometry": {"coordinates":[-114.53467999999999,33.6078],"type":"Point"}
+}

--- a/data/171/311/832/3/1713118323.geojson
+++ b/data/171/311/832/3/1713118323.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118323,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-99.9683,37.74097,-99.9683,37.74097",
+    "geom:latitude":37.74097,
+    "geom:longitude":-99.9683,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"57.0",
+    "gn:admin3_code":"18250.0",
+    "gn:asciiname":"Ranchwood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":758,
+    "gn:elevation":"751.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8123047,
+    "gn:latitude":37.74097,
+    "gn:longitude":-99.9683,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Ranchwood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-99.9883,37.72097,-99.9483,37.76097",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082141,
+        404503629,
+        85688555
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8123047
+    },
+    "wof:country":"US",
+    "wof:geomhash":"fbbf606cc5eb9433941cbc18b102fceb",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118323,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082141,
+            "localadmin_id":404503629,
+            "locality_id":-1,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1713118323,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Ranchwood Mobile Estates",
+    "wof:parent_id":404503629,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226062345
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -99.9683,
+    37.74097,
+    -99.9683,
+    37.74097
+],
+  "geometry": {"coordinates":[-99.9683,37.74097],"type":"Point"}
+}

--- a/data/171/311/832/5/1713118325.geojson
+++ b/data/171/311/832/5/1713118325.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118325,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-83.49583,43.03333,-83.49583,43.03333",
+    "geom:latitude":43.03333,
+    "geom:longitude":-83.49583,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"49.0",
+    "gn:admin3_code":"19900.0",
+    "gn:asciiname":"Davison East Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":244,
+    "gn:elevation":"244.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":9670187,
+    "gn:latitude":43.03333,
+    "gn:longitude":-83.49583,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Davison East Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-83.51583,43.01333,-83.47583,43.05333",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083111,
+        404506591,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":9670187
+    },
+    "wof:country":"US",
+    "wof:geomhash":"ce5733c79981fe90b118e53be12f8910",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118325,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083111,
+            "localadmin_id":404506591,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118325,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Davison East Mobile Estates",
+    "wof:parent_id":404506591,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309819789
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -83.49583,
+    43.03333,
+    -83.49583,
+    43.03333
+],
+  "geometry": {"coordinates":[-83.49583,43.03333],"type":"Point"}
+}

--- a/data/171/311/832/7/1713118327.geojson
+++ b/data/171/311/832/7/1713118327.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118327,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-106.57666,31.9501,-106.57666,31.9501",
+    "geom:latitude":31.9501,
+    "geom:longitude":-106.57666,
+    "gn:admin1_code":"TX",
+    "gn:admin2_code":"141.0",
+    "gn:asciiname":"Mobile Haven Estates Colonia",
+    "gn:country_code":"US",
+    "gn:dem":1208,
+    "gn:elevation":"1214.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5526498,
+    "gn:latitude":31.9501,
+    "gn:longitude":-106.57666,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Mobile Haven Estates Colonia",
+    "gn:population":0,
+    "gn:timezone":"America/Denver",
+    "iso:country":"US",
+    "lbl:bbox":"-106.59666,31.9301,-106.55666,31.9701",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085989,
+        85688753
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5526498
+    },
+    "wof:country":"US",
+    "wof:geomhash":"4ad2facb9b14d27b2372ba1462cc0ae2",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118327,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085989,
+            "locality_id":-1,
+            "region_id":85688753
+        }
+    ],
+    "wof:id":1713118327,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Mobile Haven Estates Colonia",
+    "wof:parent_id":102085989,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326765109
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -106.57666,
+    31.9501,
+    -106.57666,
+    31.9501
+],
+  "geometry": {"coordinates":[-106.57666,31.9501],"type":"Point"}
+}

--- a/data/171/311/833/1/1713118331.geojson
+++ b/data/171/311/833/1/1713118331.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118331,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.23872,47.75812,-122.23872,47.75812",
+    "geom:latitude":47.75812,
+    "geom:longitude":-122.23872,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"33.0",
+    "gn:asciiname":"Sarvis Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":10,
+    "gn:elevation":"9.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714166,
+    "gn:latitude":47.75812,
+    "gn:longitude":-122.23872,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Sarvis Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.25872,47.73812,-122.21872,47.77812",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086191,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714166
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3c6662d1333d80c1155940d463b14da7",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118331,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086191,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118331,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Sarvis Mobile Estates",
+    "wof:parent_id":102086191,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1309823509
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.23872,
+    47.75812,
+    -122.23872,
+    47.75812
+],
+  "geometry": {"coordinates":[-122.23872,47.75812],"type":"Point"}
+}

--- a/data/171/311/833/3/1713118333.geojson
+++ b/data/171/311/833/3/1713118333.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118333,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-70.69837,41.95149,-70.69837,41.95149",
+    "geom:latitude":41.95149,
+    "geom:longitude":-70.69837,
+    "gn:admin1_code":"MA",
+    "gn:admin2_code":"23.0",
+    "gn:admin3_code":"54310.0",
+    "gn:asciiname":"Plymouth Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":67,
+    "gn:elevation":"69.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4947617,
+    "gn:latitude":41.95149,
+    "gn:longitude":-70.69837,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Plymouth Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-70.71837,41.93149,-70.67837,41.97149",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084367,
+        404476561,
+        85688645
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4947617
+    },
+    "wof:country":"US",
+    "wof:geomhash":"5bc824d27fb7d07a49f1bffa2157f35d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118333,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084367,
+            "localadmin_id":404476561,
+            "locality_id":-1,
+            "region_id":85688645
+        }
+    ],
+    "wof:id":1713118333,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Plymouth Mobile Estates",
+    "wof:parent_id":404476561,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326949513
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -70.69837,
+    41.95149,
+    -70.69837,
+    41.95149
+],
+  "geometry": {"coordinates":[-70.69837,41.95149],"type":"Point"}
+}

--- a/data/171/311/833/5/1713118335.geojson
+++ b/data/171/311/833/5/1713118335.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118335,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.4502,47.13233,-122.4502,47.13233",
+    "geom:latitude":47.13233,
+    "geom:longitude":-122.4502,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"One Hundred Thirty - Eighth Park Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":91,
+    "gn:elevation":"96.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714431,
+    "gn:latitude":47.13233,
+    "gn:longitude":-122.4502,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"One Hundred Thirty - Eighth Park Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.4702,47.11233,-122.4302,47.15233",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087547,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714431
+    },
+    "wof:country":"US",
+    "wof:geomhash":"43858e3cb0177a3fce4c76483e0d0219",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118335,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087547,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118335,
+    "wof:lastmodified":1588726985,
+    "wof:name":"One Hundred Thirty - Eighth Park Mobile Estates",
+    "wof:parent_id":102087547,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326946031
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.4502,
+    47.13233,
+    -122.4502,
+    47.13233
+],
+  "geometry": {"coordinates":[-122.4502,47.13233],"type":"Point"}
+}

--- a/data/171/311/833/7/1713118337.geojson
+++ b/data/171/311/833/7/1713118337.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118337,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-112.01181,33.47532,-112.01181,33.47532",
+    "geom:latitude":33.47532,
+    "geom:longitude":-112.01181,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"13.0",
+    "gn:asciiname":"Rancho Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":353,
+    "gn:elevation":"352.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5310430,
+    "gn:latitude":33.47532,
+    "gn:longitude":-112.01181,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Rancho Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-112.03181,33.45532,-111.99181,33.49532",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087421,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5310430
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6c4bd503e8eace2a8adbd92423d08b83",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118337,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087421,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118337,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Rancho Mobile Estates",
+    "wof:parent_id":102087421,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1326866635
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -112.01181,
+    33.47532,
+    -112.01181,
+    33.47532
+],
+  "geometry": {"coordinates":[-112.01181,33.47532],"type":"Point"}
+}

--- a/data/171/311/833/9/1713118339.geojson
+++ b/data/171/311/833/9/1713118339.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118339,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.62664,39.21556,-76.62664,39.21556",
+    "geom:latitude":39.21556,
+    "geom:longitude":-76.62664,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"3",
+    "gn:asciiname":"Terrace View Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":37,
+    "gn:elevation":"38.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7228942,
+    "gn:latitude":39.21556,
+    "gn:longitude":-76.62664,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Terrace View Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.64664,39.19556,-76.60664,39.23556",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083469,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7228942
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f2480f06c21963809089641bb43e4a4c",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118339,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083469,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118339,
+    "wof:lastmodified":1588726985,
+    "wof:name":"Terrace View Mobile Estates",
+    "wof:parent_id":102083469,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276783089
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.62664,
+    39.21556,
+    -76.62664,
+    39.21556
+],
+  "geometry": {"coordinates":[-76.62663999999999,39.21556],"type":"Point"}
+}

--- a/data/171/311/834/1/1713118341.geojson
+++ b/data/171/311/834/1/1713118341.geojson
@@ -1,0 +1,77 @@
+{
+  "id": 1713118341,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-77.34691,35.62711,-77.34691,35.62711",
+    "geom:latitude":35.62711,
+    "geom:longitude":-77.34691,
+    "gn:admin1_code":"NC",
+    "gn:admin2_code":"147.0",
+    "gn:admin3_code":"92428.0",
+    "gn:asciiname":"Shady Knoll Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":9,
+    "gn:elevation":"5.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4490963,
+    "gn:latitude":35.62711,
+    "gn:longitude":-77.34691,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Shady Knoll Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-77.36691,35.60711,-77.32691,35.64711",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087595,
+        85688773
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4490963
+    },
+    "wof:country":"US",
+    "wof:geomhash":"2e293afa9b23da034a9d1333263392f8",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118341,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087595,
+            "locality_id":-1,
+            "region_id":85688773
+        }
+    ],
+    "wof:id":1713118341,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Shady Knoll Mobile Estates",
+    "wof:parent_id":102087595,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1277090135
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -77.34691,
+    35.62711,
+    -77.34691,
+    35.62711
+],
+  "geometry": {"coordinates":[-77.34690999999999,35.62711],"type":"Point"}
+}

--- a/data/171/311/834/3/1713118343.geojson
+++ b/data/171/311/834/3/1713118343.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118343,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-88.47714,30.41082,-88.47714,30.41082",
+    "geom:latitude":30.41082,
+    "geom:longitude":-88.47714,
+    "gn:admin1_code":"MS",
+    "gn:admin2_code":"59.0",
+    "gn:asciiname":"East Lawn Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":5,
+    "gn:elevation":"3.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7704272,
+    "gn:latitude":30.41082,
+    "gn:longitude":-88.47714,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"East Lawn Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-88.49714,30.39082,-88.45714,30.43082",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083161,
+        85688579
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7704272
+    },
+    "wof:country":"US",
+    "wof:geomhash":"12001747cb2f9beaec2bf1bded64d346",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118343,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083161,
+            "locality_id":-1,
+            "region_id":85688579
+        }
+    ],
+    "wof:id":1713118343,
+    "wof:lastmodified":1588726986,
+    "wof:name":"East Lawn Mobile Estates",
+    "wof:parent_id":102083161,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276790835
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -88.47714,
+    30.41082,
+    -88.47714,
+    30.41082
+],
+  "geometry": {"coordinates":[-88.47714000000001,30.41082],"type":"Point"}
+}

--- a/data/171/311/834/5/1713118345.geojson
+++ b/data/171/311/834/5/1713118345.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118345,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-92.14689,30.12494,-92.14689,30.12494",
+    "geom:latitude":30.12494,
+    "geom:longitude":-92.14689,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"55.0",
+    "gn:asciiname":"Going West Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":9,
+    "gn:elevation":"6.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7707958,
+    "gn:latitude":30.12494,
+    "gn:longitude":-92.14689,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Going West Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-92.16689,30.10494,-92.12689,30.14494",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081919,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7707958
+    },
+    "wof:country":"US",
+    "wof:geomhash":"da250212fa86bcdfda90832979c894f6",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118345,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081919,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118345,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Going West Mobile Estates",
+    "wof:parent_id":102081919,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276239221
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -92.14689,
+    30.12494,
+    -92.14689,
+    30.12494
+],
+  "geometry": {"coordinates":[-92.14689,30.12494],"type":"Point"}
+}

--- a/data/171/311/834/9/1713118349.geojson
+++ b/data/171/311/834/9/1713118349.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118349,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.49969,48.78697,-122.49969,48.78697",
+    "geom:latitude":48.78697,
+    "geom:longitude":-122.49969,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"73.0",
+    "gn:asciiname":"Bakerview Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":51,
+    "gn:elevation":"52.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713990,
+    "gn:latitude":48.78697,
+    "gn:longitude":-122.49969,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Bakerview Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.51969,48.76697,-122.47969,48.80697",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085363,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713990
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3618f4c40f8beae19acd7ae05f3e6c23",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118349,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085363,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118349,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Bakerview Mobile Estates",
+    "wof:parent_id":102085363,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276158073
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.49969,
+    48.78697,
+    -122.49969,
+    48.78697
+],
+  "geometry": {"coordinates":[-122.49969,48.78697],"type":"Point"}
+}

--- a/data/171/311/835/1/1713118351.geojson
+++ b/data/171/311/835/1/1713118351.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118351,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-112.31627,33.46254,-112.31627,33.46254",
+    "geom:latitude":33.46254,
+    "geom:longitude":-112.31627,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"13.0",
+    "gn:asciiname":"Country Hills Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":299,
+    "gn:elevation":"302.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5291305,
+    "gn:latitude":33.46254,
+    "gn:longitude":-112.31627,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Country Hills Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-112.33627,33.44254,-112.29627,33.48254",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087421,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5291305
+    },
+    "wof:country":"US",
+    "wof:geomhash":"7de5971f46926a5d544823f62c4279a1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118351,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087421,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118351,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Country Hills Mobile Estates",
+    "wof:parent_id":102087421,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276693935
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -112.31627,
+    33.46254,
+    -112.31627,
+    33.46254
+],
+  "geometry": {"coordinates":[-112.31627,33.46254],"type":"Point"}
+}

--- a/data/171/311/835/3/1713118353.geojson
+++ b/data/171/311/835/3/1713118353.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118353,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-88.91278,30.44228,-88.91278,30.44228",
+    "geom:latitude":30.44228,
+    "geom:longitude":-88.91278,
+    "gn:admin1_code":"MS",
+    "gn:admin2_code":"47.0",
+    "gn:asciiname":"Rolling Heights Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":10,
+    "gn:elevation":"9.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7704851,
+    "gn:latitude":30.44228,
+    "gn:longitude":-88.91278,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Rolling Heights Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-88.93278,30.42228,-88.89278,30.46228",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087223,
+        85688579
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7704851
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6d1bca156411654f2ec9e2489f3b36ed",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118353,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087223,
+            "locality_id":-1,
+            "region_id":85688579
+        }
+    ],
+    "wof:id":1713118353,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Rolling Heights Mobile Estates",
+    "wof:parent_id":102087223,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276573985
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -88.91278,
+    30.44228,
+    -88.91278,
+    30.44228
+],
+  "geometry": {"coordinates":[-88.91278,30.44228],"type":"Point"}
+}

--- a/data/171/311/835/5/1713118355.geojson
+++ b/data/171/311/835/5/1713118355.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118355,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.21444,47.3395,-122.21444,47.3395",
+    "geom:latitude":47.3395,
+    "geom:longitude":-122.21444,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"33.0",
+    "gn:asciiname":"The River Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":15,
+    "gn:elevation":"16.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713983,
+    "gn:latitude":47.3395,
+    "gn:longitude":-122.21444,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"The River Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.23444,47.3195,-122.19444,47.3595",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086191,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713983
+    },
+    "wof:country":"US",
+    "wof:geomhash":"eea0bce627299b406d658ad2a19cabd2",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118355,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086191,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118355,
+    "wof:lastmodified":1588726986,
+    "wof:name":"The River Mobile Estates",
+    "wof:parent_id":102086191,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1277085277
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.21444,
+    47.3395,
+    -122.21444,
+    47.3395
+],
+  "geometry": {"coordinates":[-122.21444,47.3395],"type":"Point"}
+}

--- a/data/171/311/835/7/1713118357.geojson
+++ b/data/171/311/835/7/1713118357.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118357,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.3136,27.9948,-82.3136,27.9948",
+    "geom:latitude":27.9948,
+    "geom:longitude":-82.3136,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"57",
+    "gn:asciiname":"Hillcrest Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":19,
+    "gn:elevation":"10.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7218016,
+    "gn:latitude":27.9948,
+    "gn:longitude":-82.3136,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Hillcrest Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.3336,27.9748,-82.2936,28.0148",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085773,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7218016
+    },
+    "wof:country":"US",
+    "wof:geomhash":"67aabadd89192dc7d5524bbfe4c4e431",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118357,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085773,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118357,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Hillcrest Mobile Estates",
+    "wof:parent_id":102085773,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276997295
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.3136,
+    27.9948,
+    -82.3136,
+    27.9948
+],
+  "geometry": {"coordinates":[-82.31359999999999,27.9948],"type":"Point"}
+}

--- a/data/171/311/835/9/1713118359.geojson
+++ b/data/171/311/835/9/1713118359.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118359,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.40902,31.2604,-85.40902,31.2604",
+    "geom:latitude":31.2604,
+    "geom:longitude":-85.40902,
+    "gn:admin1_code":"AL",
+    "gn:admin2_code":"69.0",
+    "gn:asciiname":"La Vista Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":93,
+    "gn:elevation":"93.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7313406,
+    "gn:latitude":31.2604,
+    "gn:longitude":-85.40902,
+    "gn:modification_date":"2011-01-10",
+    "gn:name":"La Vista Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-85.42902,31.2404,-85.38902,31.2804",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085441,
+        85688675
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7313406
+    },
+    "wof:country":"US",
+    "wof:geomhash":"8d425581dd862c0f1a6d8cb60a75e206",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118359,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085441,
+            "locality_id":-1,
+            "region_id":85688675
+        }
+    ],
+    "wof:id":1713118359,
+    "wof:lastmodified":1588726986,
+    "wof:name":"La Vista Mobile Estates",
+    "wof:parent_id":102085441,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1277007773
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.40902,
+    31.2604,
+    -85.40902,
+    31.2604
+],
+  "geometry": {"coordinates":[-85.40902,31.2604],"type":"Point"}
+}

--- a/data/171/311/836/1/1713118361.geojson
+++ b/data/171/311/836/1/1713118361.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118361,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-88.91589,30.4418,-88.91589,30.4418",
+    "geom:latitude":30.4418,
+    "geom:longitude":-88.91589,
+    "gn:admin1_code":"MS",
+    "gn:admin2_code":"47.0",
+    "gn:asciiname":"Rolling Hills Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":9,
+    "gn:elevation":"10.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7704546,
+    "gn:latitude":30.4418,
+    "gn:longitude":-88.91589,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Rolling Hills Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-88.93589,30.4218,-88.89589,30.4618",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087223,
+        85688579
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7704546
+    },
+    "wof:country":"US",
+    "wof:geomhash":"d1ca98e565284a160535161457f22317",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118361,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087223,
+            "locality_id":-1,
+            "region_id":85688579
+        }
+    ],
+    "wof:id":1713118361,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Rolling Hills Mobile Estates",
+    "wof:parent_id":102087223,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1277006257
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -88.91589,
+    30.4418,
+    -88.91589,
+    30.4418
+],
+  "geometry": {"coordinates":[-88.91589,30.4418],"type":"Point"}
+}

--- a/data/171/311/836/3/1713118363.geojson
+++ b/data/171/311/836/3/1713118363.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118363,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.34738,31.28842,-85.34738,31.28842",
+    "geom:latitude":31.28842,
+    "geom:longitude":-85.34738,
+    "gn:admin1_code":"AL",
+    "gn:admin2_code":"69.0",
+    "gn:asciiname":"Pointe South Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":91,
+    "gn:elevation":"91.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7313409,
+    "gn:latitude":31.28842,
+    "gn:longitude":-85.34738,
+    "gn:modification_date":"2011-01-10",
+    "gn:name":"Pointe South Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-85.36738,31.26842,-85.32738,31.30842",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085441,
+        85688675
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7313409
+    },
+    "wof:country":"US",
+    "wof:geomhash":"2ba41144461bef03323c3950f35b21bd",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118363,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085441,
+            "locality_id":-1,
+            "region_id":85688675
+        }
+    ],
+    "wof:id":1713118363,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Pointe South Mobile Estates",
+    "wof:parent_id":102085441,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1277001733
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.34738,
+    31.28842,
+    -85.34738,
+    31.28842
+],
+  "geometry": {"coordinates":[-85.34738,31.28842],"type":"Point"}
+}

--- a/data/171/311/836/7/1713118367.geojson
+++ b/data/171/311/836/7/1713118367.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118367,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-73.88806,43.14528,-73.88806,43.14528",
+    "geom:latitude":43.14528,
+    "geom:longitude":-73.88806,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"91",
+    "gn:admin3_code":"30444.0",
+    "gn:asciiname":"Della Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":204,
+    "gn:elevation":"202.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7226948,
+    "gn:latitude":43.14528,
+    "gn:longitude":-73.88806,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Della Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-73.90806,43.12528,-73.86806,43.16528",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082413,
+        404523169,
+        85688543
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7226948
+    },
+    "wof:country":"US",
+    "wof:geomhash":"2a76697067a9c016970f8815ce5de4cf",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118367,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082413,
+            "localadmin_id":404523169,
+            "locality_id":-1,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1713118367,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Della Mobile Estates",
+    "wof:parent_id":404523169,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1276139217
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -73.88806,
+    43.14528,
+    -73.88806,
+    43.14528
+],
+  "geometry": {"coordinates":[-73.88806,43.14528],"type":"Point"}
+}

--- a/data/171/311/836/9/1713118369.geojson
+++ b/data/171/311/836/9/1713118369.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118369,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.2825,41.69639,-81.2825,41.69639",
+    "geom:latitude":41.69639,
+    "geom:longitude":-81.2825,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"85",
+    "gn:admin3_code":"59430.0",
+    "gn:asciiname":"Avenues Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":208,
+    "gn:elevation":"207.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7234343,
+    "gn:latitude":41.69639,
+    "gn:longitude":-81.2825,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Avenues Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.3025,41.67639,-81.2625,41.71639",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083703,
+        404526955,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7234343
+    },
+    "wof:country":"US",
+    "wof:geomhash":"1160c2da006c762c6c020901920a25e2",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118369,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083703,
+            "localadmin_id":404526955,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118369,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Avenues Mobile Estates",
+    "wof:parent_id":404526955,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226555573
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.2825,
+    41.69639,
+    -81.2825,
+    41.69639
+],
+  "geometry": {"coordinates":[-81.2825,41.69639],"type":"Point"}
+}

--- a/data/171/311/837/1/1713118371.geojson
+++ b/data/171/311/837/1/1713118371.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118371,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-86.29639,42.18556,-86.29639,42.18556",
+    "geom:latitude":42.18556,
+    "geom:longitude":-86.29639,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"21",
+    "gn:admin3_code":"17340.0",
+    "gn:asciiname":"Hillview Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":204,
+    "gn:elevation":"208.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7159830,
+    "gn:latitude":42.18556,
+    "gn:longitude":-86.29639,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Hillview Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-86.31639,42.16556,-86.27639,42.20556",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083151,
+        404506991,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7159830
+    },
+    "wof:country":"US",
+    "wof:geomhash":"797ed0fec3da964944dde643a7042090",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118371,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083151,
+            "localadmin_id":404506991,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118371,
+    "wof:lastmodified":1588726986,
+    "wof:name":"Hillview Mobile Estates",
+    "wof:parent_id":404506991,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1225955181
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -86.29639,
+    42.18556,
+    -86.29639,
+    42.18556
+],
+  "geometry": {"coordinates":[-86.29639,42.18556],"type":"Point"}
+}

--- a/data/171/311/837/3/1713118373.geojson
+++ b/data/171/311/837/3/1713118373.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118373,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.33694,40.71278,-122.33694,40.71278",
+    "geom:latitude":40.71278,
+    "geom:longitude":-122.33694,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"89",
+    "gn:asciiname":"Redding Lakeside Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":277,
+    "gn:elevation":"275.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7232377,
+    "gn:latitude":40.71278,
+    "gn:longitude":-122.33694,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Redding Lakeside Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.35694,40.69278,-122.31694,40.73278",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083577,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7232377
+    },
+    "wof:country":"US",
+    "wof:geomhash":"0474fb74fa36d31ed38a05d238f30ed4",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118373,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083577,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118373,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Redding Lakeside Mobile Estates",
+    "wof:parent_id":102083577,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1226550813
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.33694,
+    40.71278,
+    -122.33694,
+    40.71278
+],
+  "geometry": {"coordinates":[-122.33694,40.71278],"type":"Point"}
+}

--- a/data/171/311/837/5/1713118375.geojson
+++ b/data/171/311/837/5/1713118375.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118375,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.43054,47.10874,-122.43054,47.10874",
+    "geom:latitude":47.10874,
+    "geom:longitude":-122.43054,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"Country Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":111,
+    "gn:elevation":"109.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714412,
+    "gn:latitude":47.10874,
+    "gn:longitude":-122.43054,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Country Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.45054,47.08874,-122.41054,47.12874",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714412
+    },
+    "wof:country":"US",
+    "wof:geomhash":"5190cda90605e553bdb96efbea4d0967",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118375,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118375,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Country Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209434599
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.43054,
+    47.10874,
+    -122.43054,
+    47.10874
+],
+  "geometry": {"coordinates":[-122.43053999999999,47.10874],"type":"Point"}
+}

--- a/data/171/311/837/7/1713118377.geojson
+++ b/data/171/311/837/7/1713118377.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118377,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.98595,29.12829,-80.98595,29.12829",
+    "geom:latitude":29.12829,
+    "geom:longitude":-80.98595,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"127.0",
+    "gn:asciiname":"Tanglewood Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":5,
+    "gn:elevation":"3.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7192812,
+    "gn:latitude":29.12829,
+    "gn:longitude":-80.98595,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Tanglewood Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.00595,29.10829,-80.96595,29.14829",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7192812
+    },
+    "wof:country":"US",
+    "wof:geomhash":"2e2c405617365f357ad8ee93f2ba5b55",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118377,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118377,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Tanglewood Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209434619
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.98595,
+    29.12829,
+    -80.98595,
+    29.12829
+],
+  "geometry": {"coordinates":[-80.98595,29.12829],"type":"Point"}
+}

--- a/data/171/311/837/9/1713118379.geojson
+++ b/data/171/311/837/9/1713118379.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118379,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-92.06087,30.27509,-92.06087,30.27509",
+    "geom:latitude":30.27509,
+    "geom:longitude":-92.06087,
+    "gn:admin1_code":"LA",
+    "gn:admin2_code":"55.0",
+    "gn:asciiname":"Country Pine Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":14,
+    "gn:elevation":"13.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7708244,
+    "gn:latitude":30.27509,
+    "gn:longitude":-92.06087,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Country Pine Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-92.08087,30.25509,-92.04087,30.29509",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081919,
+        85688735
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7708244
+    },
+    "wof:country":"US",
+    "wof:geomhash":"d04a1441269dfefb5a8edac8e0330dac",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118379,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081919,
+            "locality_id":-1,
+            "region_id":85688735
+        }
+    ],
+    "wof:id":1713118379,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Country Pine Mobile Estates",
+    "wof:parent_id":102081919,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209925213
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -92.06087,
+    30.27509,
+    -92.06087,
+    30.27509
+],
+  "geometry": {"coordinates":[-92.06086999999999,30.27509],"type":"Point"}
+}

--- a/data/171/311/838/1/1713118381.geojson
+++ b/data/171/311/838/1/1713118381.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118381,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.19005,47.81056,-122.19005,47.81056",
+    "geom:latitude":47.81056,
+    "geom:longitude":-122.19005,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"61.0",
+    "gn:asciiname":"Cascade Vista Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":127,
+    "gn:elevation":"121.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714012,
+    "gn:latitude":47.81056,
+    "gn:longitude":-122.19005,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Cascade Vista Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.21005,47.79056,-122.17005,47.83056",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714012
+    },
+    "wof:country":"US",
+    "wof:geomhash":"36a6e675cc6e617a6392c6387ea0a9ee",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118381,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118381,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Cascade Vista Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209425907
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.19005,
+    47.81056,
+    -122.19005,
+    47.81056
+],
+  "geometry": {"coordinates":[-122.19005,47.81056],"type":"Point"}
+}

--- a/data/171/311/838/5/1713118385.geojson
+++ b/data/171/311/838/5/1713118385.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118385,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.65349,48.30122,-122.65349,48.30122",
+    "geom:latitude":48.30122,
+    "geom:longitude":-122.65349,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"29.0",
+    "gn:asciiname":"Western Village Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":21,
+    "gn:elevation":"22.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714272,
+    "gn:latitude":48.30122,
+    "gn:longitude":-122.65349,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Western Village Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.67349,48.28122,-122.63349,48.32122",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087543,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714272
+    },
+    "wof:country":"US",
+    "wof:geomhash":"93a17e337024b5271668f29f0663f0d6",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118385,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087543,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118385,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Western Village Mobile Estates",
+    "wof:parent_id":102087543,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310517867
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.65349,
+    48.30122,
+    -122.65349,
+    48.30122
+],
+  "geometry": {"coordinates":[-122.65349000000001,48.30122],"type":"Point"}
+}

--- a/data/171/311/838/7/1713118387.geojson
+++ b/data/171/311/838/7/1713118387.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118387,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.64972,41.71639,-122.64972,41.71639",
+    "geom:latitude":41.71639,
+    "geom:longitude":-122.64972,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"93",
+    "gn:asciiname":"Oak Ridge Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":850,
+    "gn:elevation":"844.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7236202,
+    "gn:latitude":41.71639,
+    "gn:longitude":-122.64972,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Oak Ridge Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.66972,41.69639,-122.62972,41.73639",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081669,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7236202
+    },
+    "wof:country":"US",
+    "wof:geomhash":"1945371dd7634c52a9a5367001b09ad3",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118387,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081669,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118387,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Oak Ridge Mobile Estates",
+    "wof:parent_id":102081669,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310442099
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.64972,
+    41.71639,
+    -122.64972,
+    41.71639
+],
+  "geometry": {"coordinates":[-122.64972,41.71639],"type":"Point"}
+}

--- a/data/171/311/838/9/1713118389.geojson
+++ b/data/171/311/838/9/1713118389.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118389,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-114.62602,32.66478,-114.62602,32.66478",
+    "geom:latitude":32.66478,
+    "geom:longitude":-114.62602,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"27.0",
+    "gn:asciiname":"Mesa Terrace Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":61,
+    "gn:elevation":"61.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7723174,
+    "gn:latitude":32.66478,
+    "gn:longitude":-114.62602,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Mesa Terrace Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-114.64602,32.64478,-114.60602,32.68478",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081527,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7723174
+    },
+    "wof:country":"US",
+    "wof:geomhash":"d143de69200540c4ccea4b2fb6b85f6b",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118389,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081527,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118389,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Mesa Terrace Mobile Estates",
+    "wof:parent_id":102081527,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310442429
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -114.62602,
+    32.66478,
+    -114.62602,
+    32.66478
+],
+  "geometry": {"coordinates":[-114.62602,32.66478],"type":"Point"}
+}

--- a/data/171/311/839/1/1713118391.geojson
+++ b/data/171/311/839/1/1713118391.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118391,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-88.948,30.44092,-88.948,30.44092",
+    "geom:latitude":30.44092,
+    "geom:longitude":-88.948,
+    "gn:admin1_code":"MS",
+    "gn:admin2_code":"47.0",
+    "gn:asciiname":"Imperial Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":17,
+    "gn:elevation":"15.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7704441,
+    "gn:latitude":30.44092,
+    "gn:longitude":-88.948,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Imperial Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-88.968,30.42092,-88.928,30.46092",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087223,
+        85688579
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7704441
+    },
+    "wof:country":"US",
+    "wof:geomhash":"db0cb79b7994380381d3fafebad09927",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118391,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087223,
+            "locality_id":-1,
+            "region_id":85688579
+        }
+    ],
+    "wof:id":1713118391,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Imperial Mobile Estates",
+    "wof:parent_id":102087223,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310429751
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -88.948,
+    30.44092,
+    -88.948,
+    30.44092
+],
+  "geometry": {"coordinates":[-88.94799999999999,30.44092],"type":"Point"}
+}

--- a/data/171/311/839/3/1713118393.geojson
+++ b/data/171/311/839/3/1713118393.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118393,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.27972,40.46528,-122.27972,40.46528",
+    "geom:latitude":40.46528,
+    "geom:longitude":-122.27972,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"89",
+    "gn:asciiname":"River Park Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":127,
+    "gn:elevation":"126.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7232379,
+    "gn:latitude":40.46528,
+    "gn:longitude":-122.27972,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"River Park Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.29972,40.44528,-122.25972,40.48528",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083577,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7232379
+    },
+    "wof:country":"US",
+    "wof:geomhash":"27cf061782fa02dc662cea8db4b63d8e",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118393,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083577,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118393,
+    "wof:lastmodified":1588726987,
+    "wof:name":"River Park Mobile Estates",
+    "wof:parent_id":102083577,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310142707
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.27972,
+    40.46528,
+    -122.27972,
+    40.46528
+],
+  "geometry": {"coordinates":[-122.27972,40.46528],"type":"Point"}
+}

--- a/data/171/311/839/5/1713118395.geojson
+++ b/data/171/311/839/5/1713118395.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118395,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.18969,48.51669,-122.18969,48.51669",
+    "geom:latitude":48.51669,
+    "geom:longitude":-122.18969,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"57.0",
+    "gn:asciiname":"Cedar Lane Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":20,
+    "gn:elevation":"21.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714340,
+    "gn:latitude":48.51669,
+    "gn:longitude":-122.18969,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Cedar Lane Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.20969,48.49669,-122.16969,48.53669",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084225,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714340
+    },
+    "wof:country":"US",
+    "wof:geomhash":"14e9d70a17240dad8d21ef3278696cec",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118395,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084225,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118395,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Cedar Lane Mobile Estates",
+    "wof:parent_id":102084225,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209951291
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.18969,
+    48.51669,
+    -122.18969,
+    48.51669
+],
+  "geometry": {"coordinates":[-122.18969,48.51669],"type":"Point"}
+}

--- a/data/171/311/839/7/1713118397.geojson
+++ b/data/171/311/839/7/1713118397.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118397,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-123.16038,48.07916,-123.16038,48.07916",
+    "geom:latitude":48.07916,
+    "geom:longitude":-123.16038,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"9.0",
+    "gn:asciiname":"Green Acres Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":76,
+    "gn:elevation":"74.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714352,
+    "gn:latitude":48.07916,
+    "gn:longitude":-123.16038,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Green Acres Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-123.18038,48.05916,-123.14038,48.09916",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084229,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714352
+    },
+    "wof:country":"US",
+    "wof:geomhash":"03efc9f57f6cf0f53214320f36661aed",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118397,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084229,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118397,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Green Acres Mobile Estates",
+    "wof:parent_id":102084229,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259808097
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -123.16038,
+    48.07916,
+    -123.16038,
+    48.07916
+],
+  "geometry": {"coordinates":[-123.16038,48.07916],"type":"Point"}
+}

--- a/data/171/311/839/9/1713118399.geojson
+++ b/data/171/311/839/9/1713118399.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118399,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-119.28039,34.43555,-119.28039,34.43555",
+    "geom:latitude":34.43555,
+    "geom:longitude":-119.28039,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"111",
+    "gn:asciiname":"Del Francia Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":208,
+    "gn:elevation":"203.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5342350,
+    "gn:latitude":34.43555,
+    "gn:longitude":-119.28039,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Del Francia Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-119.30039,34.41555,-119.26039,34.45555",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086933,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5342350
+    },
+    "wof:country":"US",
+    "wof:geomhash":"5f83e1ee730adb750356815875c47776",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118399,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086933,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118399,
+    "wof:lastmodified":1588726987,
+    "wof:name":"Del Francia Mobile Estates",
+    "wof:parent_id":102086933,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259617821
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -119.28039,
+    34.43555,
+    -119.28039,
+    34.43555
+],
+  "geometry": {"coordinates":[-119.28039,34.43555],"type":"Point"}
+}

--- a/data/171/311/840/3/1713118403.geojson
+++ b/data/171/311/840/3/1713118403.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118403,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-87.02713,37.79039,-87.02713,37.79039",
+    "geom:latitude":37.79039,
+    "geom:longitude":-87.02713,
+    "gn:admin1_code":"KY",
+    "gn:admin2_code":"59.0",
+    "gn:asciiname":"Colonial Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":117,
+    "gn:elevation":"120.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8503428,
+    "gn:latitude":37.79039,
+    "gn:longitude":-87.02713,
+    "gn:modification_date":"2013-03-09",
+    "gn:name":"Colonial Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-87.04713,37.77039,-87.00713,37.81039",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085691,
+        85688641
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8503428
+    },
+    "wof:country":"US",
+    "wof:geomhash":"8db7b2b05c588c7d5f0de7b1f68f6930",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118403,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085691,
+            "locality_id":-1,
+            "region_id":85688641
+        }
+    ],
+    "wof:id":1713118403,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Colonial Mobile Estates",
+    "wof:parent_id":102085691,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259499655
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -87.02713,
+    37.79039,
+    -87.02713,
+    37.79039
+],
+  "geometry": {"coordinates":[-87.02713,37.79039],"type":"Point"}
+}

--- a/data/171/311/840/5/1713118405.geojson
+++ b/data/171/311/840/5/1713118405.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118405,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-123.57315,46.98306,-123.57315,46.98306",
+    "geom:latitude":46.98306,
+    "geom:longitude":-123.57315,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"27.0",
+    "gn:asciiname":"Evergreen Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":10,
+    "gn:elevation":"12.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714248,
+    "gn:latitude":46.98306,
+    "gn:longitude":-123.57315,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Evergreen Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-123.59315,46.96306,-123.55315,47.00306",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714248
+    },
+    "wof:country":"US",
+    "wof:geomhash":"83b95f31f9c1b9415ec2308c47fbb985",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118405,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118405,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Evergreen Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209029341
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -123.57315,
+    46.98306,
+    -123.57315,
+    46.98306
+],
+  "geometry": {"coordinates":[-123.57315,46.98306],"type":"Point"}
+}

--- a/data/171/311/840/7/1713118407.geojson
+++ b/data/171/311/840/7/1713118407.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118407,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-96.87864,37.76718,-96.87864,37.76718",
+    "geom:latitude":37.76718,
+    "geom:longitude":-96.87864,
+    "gn:admin1_code":"KS",
+    "gn:admin2_code":"15.0",
+    "gn:admin3_code":"20100.0",
+    "gn:asciiname":"El Dorado Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":396,
+    "gn:elevation":"391.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8122743,
+    "gn:latitude":37.76718,
+    "gn:longitude":-96.87864,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"El Dorado Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-96.89864,37.74718,-96.85864,37.78718",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082695,
+        404503819,
+        85688555
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8122743
+    },
+    "wof:country":"US",
+    "wof:geomhash":"c175fcb4b20d09945cf44bcd4325f84a",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118407,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082695,
+            "localadmin_id":404503819,
+            "locality_id":-1,
+            "region_id":85688555
+        }
+    ],
+    "wof:id":1713118407,
+    "wof:lastmodified":1588726988,
+    "wof:name":"El Dorado Mobile Estates",
+    "wof:parent_id":404503819,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259507985
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -96.87864,
+    37.76718,
+    -96.87864,
+    37.76718
+],
+  "geometry": {"coordinates":[-96.87864,37.76718],"type":"Point"}
+}

--- a/data/171/311/840/9/1713118409.geojson
+++ b/data/171/311/840/9/1713118409.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118409,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.82306,42.51806,-85.82306,42.51806",
+    "geom:latitude":42.51806,
+    "geom:longitude":-85.82306,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"5.0",
+    "gn:admin3_code":"1280.0",
+    "gn:asciiname":"Allegan Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":208,
+    "gn:elevation":"197.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7308644,
+    "gn:latitude":42.51806,
+    "gn:longitude":-85.82306,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Allegan Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-85.84306,42.49806,-85.80306,42.53806",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083043,
+        404506771,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7308644
+    },
+    "wof:country":"US",
+    "wof:geomhash":"149847b859a46d0aada03f69eda7f230",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118409,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083043,
+            "localadmin_id":404506771,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118409,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Allegan Mobile Estates",
+    "wof:parent_id":404506771,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259503169
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.82306,
+    42.51806,
+    -85.82306,
+    42.51806
+],
+  "geometry": {"coordinates":[-85.82306,42.51806],"type":"Point"}
+}

--- a/data/171/311/841/1/1713118411.geojson
+++ b/data/171/311/841/1/1713118411.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118411,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.37972,41.40389,-122.37972,41.40389",
+    "geom:latitude":41.40389,
+    "geom:longitude":-122.37972,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"93",
+    "gn:asciiname":"Cal-ore Trail Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":1127,
+    "gn:elevation":"1123.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7236197,
+    "gn:latitude":41.40389,
+    "gn:longitude":-122.37972,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Cal-ore Trail Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.39972,41.38389,-122.35972,41.42389",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081669,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7236197
+    },
+    "wof:country":"US",
+    "wof:geomhash":"64960f7a4d30a011dc3fb636883c0f27",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118411,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081669,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118411,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Cal-ore Trail Mobile Estates",
+    "wof:parent_id":102081669,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259820317
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.37972,
+    41.40389,
+    -122.37972,
+    41.40389
+],
+  "geometry": {"coordinates":[-122.37972000000001,41.40389],"type":"Point"}
+}

--- a/data/171/311/841/3/1713118413.geojson
+++ b/data/171/311/841/3/1713118413.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118413,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-85.3826,31.18889,-85.3826,31.18889",
+    "geom:latitude":31.18889,
+    "geom:longitude":-85.3826,
+    "gn:admin1_code":"AL",
+    "gn:admin2_code":"69.0",
+    "gn:asciiname":"Grand Villa Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":95,
+    "gn:elevation":"93.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7313401,
+    "gn:latitude":31.18889,
+    "gn:longitude":-85.3826,
+    "gn:modification_date":"2011-01-10",
+    "gn:name":"Grand Villa Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-85.4026,31.16889,-85.3626,31.20889",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085441,
+        85688675
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7313401
+    },
+    "wof:country":"US",
+    "wof:geomhash":"63f1838dae6b58d346fc7902dad5e970",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118413,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085441,
+            "locality_id":-1,
+            "region_id":85688675
+        }
+    ],
+    "wof:id":1713118413,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Grand Villa Mobile Estates",
+    "wof:parent_id":102085441,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259799915
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -85.3826,
+    31.18889,
+    -85.3826,
+    31.18889
+],
+  "geometry": {"coordinates":[-85.3826,31.18889],"type":"Point"}
+}

--- a/data/171/311/841/5/1713118415.geojson
+++ b/data/171/311/841/5/1713118415.geojson
@@ -1,0 +1,78 @@
+{
+  "id": 1713118415,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.57,39.71278,-82.57,39.71278",
+    "geom:latitude":39.71278,
+    "geom:longitude":-82.57,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"45.0",
+    "gn:asciiname":"Lancaster Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":252,
+    "gn:elevation":"254.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7199964,
+    "gn:latitude":39.71278,
+    "gn:longitude":-82.57,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Lancaster Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.59,39.69278,-82.55,39.73278",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083747,
+        404524579,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7199964
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3567804b095fcc676856731d8a456ee5",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118415,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083747,
+            "localadmin_id":404524579,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118415,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Lancaster Mobile Estates",
+    "wof:parent_id":404524579,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259594491
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.57,
+    39.71278,
+    -82.57,
+    39.71278
+],
+  "geometry": {"coordinates":[-82.56999999999999,39.71278],"type":"Point"}
+}

--- a/data/171/311/841/7/1713118417.geojson
+++ b/data/171/311/841/7/1713118417.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118417,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.64546,47.62415,-122.64546,47.62415",
+    "geom:latitude":47.62415,
+    "geom:longitude":-122.64546,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"35.0",
+    "gn:asciiname":"Silverdale Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":47,
+    "gn:elevation":"44.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":9670153,
+    "gn:latitude":47.62415,
+    "gn:longitude":-122.64546,
+    "gn:modification_date":"2014-10-09",
+    "gn:name":"Silverdale Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.66546,47.60415,-122.62546,47.64415",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081243,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":9670153
+    },
+    "wof:country":"US",
+    "wof:geomhash":"a02b7db6d5554492ef61369613e727dd",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118417,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081243,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118417,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Silverdale Mobile Estates",
+    "wof:parent_id":102081243,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259896071
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.64546,
+    47.62415,
+    -122.64546,
+    47.62415
+],
+  "geometry": {"coordinates":[-122.64546,47.62415],"type":"Point"}
+}

--- a/data/171/311/842/1/1713118421.geojson
+++ b/data/171/311/842/1/1713118421.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118421,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-86.52083,42.00806,-86.52083,42.00806",
+    "geom:latitude":42.00806,
+    "geom:longitude":-86.52083,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"21",
+    "gn:admin3_code":"47600.0",
+    "gn:asciiname":"Lakeshore Mobile Estates Park",
+    "gn:country_code":"US",
+    "gn:dem":192,
+    "gn:elevation":"197.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7160049,
+    "gn:latitude":42.00806,
+    "gn:longitude":-86.52083,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Lakeshore Mobile Estates Park",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-86.54083,41.98806,-86.50083,42.02806",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083151,
+        404506997,
+        85688599
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7160049
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f7b934a370ee321d54c5ff64c6960af8",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118421,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083151,
+            "localadmin_id":404506997,
+            "locality_id":-1,
+            "region_id":85688599
+        }
+    ],
+    "wof:id":1713118421,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Lakeshore Mobile Estates Park",
+    "wof:parent_id":404506997,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259916499
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -86.52083,
+    42.00806,
+    -86.52083,
+    42.00806
+],
+  "geometry": {"coordinates":[-86.52083,42.00806],"type":"Point"}
+}

--- a/data/171/311/842/3/1713118423.geojson
+++ b/data/171/311/842/3/1713118423.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118423,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.35529,41.33793,-122.35529,41.33793",
+    "geom:latitude":41.33793,
+    "geom:longitude":-122.35529,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"93.0",
+    "gn:asciiname":"Abrams Lake Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":1145,
+    "gn:elevation":"1134.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5558688,
+    "gn:latitude":41.33793,
+    "gn:longitude":-122.35529,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Abrams Lake Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.37529,41.31793,-122.33529,41.35793",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081669,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5558688
+    },
+    "wof:country":"US",
+    "wof:geomhash":"1c8ee850e5692af2243aa86986d22437",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118423,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081669,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118423,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Abrams Lake Mobile Estates",
+    "wof:parent_id":102081669,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209731349
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.35529,
+    41.33793,
+    -122.35529,
+    41.33793
+],
+  "geometry": {"coordinates":[-122.35529,41.33793],"type":"Point"}
+}

--- a/data/171/311/842/5/1713118425.geojson
+++ b/data/171/311/842/5/1713118425.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118425,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.67548,38.80792,-76.67548,38.80792",
+    "geom:latitude":38.80792,
+    "geom:longitude":-76.67548,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"3",
+    "gn:asciiname":"Boone's Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":30,
+    "gn:elevation":"32.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7228536,
+    "gn:latitude":38.80792,
+    "gn:longitude":-76.67548,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Boone's Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.69548,38.78792,-76.65548,38.82792",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083469,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7228536
+    },
+    "wof:country":"US",
+    "wof:geomhash":"3912fa0cb722b3ee97e5837f460493e6",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118425,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083469,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118425,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Boone's Mobile Estates",
+    "wof:parent_id":102083469,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209735095
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.67548,
+    38.80792,
+    -76.67548,
+    38.80792
+],
+  "geometry": {"coordinates":[-76.67547999999999,38.80792],"type":"Point"}
+}

--- a/data/171/311/842/7/1713118427.geojson
+++ b/data/171/311/842/7/1713118427.geojson
@@ -1,0 +1,71 @@
+{
+  "id": 1713118427,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-84.59639,42.71056,-84.59639,42.71056",
+    "geom:latitude":42.71056,
+    "geom:longitude":-84.59639,
+    "gn:admin1_code":"MI",
+    "gn:admin2_code":"65.0",
+    "gn:admin3_code":"46000.0",
+    "gn:asciiname":"Riverview Estates Mobile Community",
+    "gn:country_code":"US",
+    "gn:dem":262,
+    "gn:elevation":"261.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8086457,
+    "gn:latitude":42.71056,
+    "gn:longitude":-84.59639,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Riverview Estates Mobile Community",
+    "gn:population":0,
+    "gn:timezone":"America/Detroit",
+    "iso:country":"US",
+    "lbl:bbox":"-84.61639,42.69056,-84.57639,42.73056",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8086457
+    },
+    "wof:country":"US",
+    "wof:geomhash":"0a13950f48e5fad8a4bd85039fa54613",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118427,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118427,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Riverview Estates Mobile Community",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209626617
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -84.59639,
+    42.71056,
+    -84.59639,
+    42.71056
+],
+  "geometry": {"coordinates":[-84.59639,42.71056],"type":"Point"}
+}

--- a/data/171/311/842/9/1713118429.geojson
+++ b/data/171/311/842/9/1713118429.geojson
@@ -1,0 +1,71 @@
+{
+  "id": 1713118429,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-96.58944,46.25444,-96.58944,46.25444",
+    "geom:latitude":46.25444,
+    "geom:longitude":-96.58944,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"167.0",
+    "gn:admin3_code":"7462.0",
+    "gn:asciiname":"Boise De Sioux Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":291,
+    "gn:elevation":"293.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5018910,
+    "gn:latitude":46.25444,
+    "gn:longitude":-96.58944,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Boise De Sioux Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-96.60944,46.23444,-96.56944,46.27444",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5018910
+    },
+    "wof:country":"US",
+    "wof:geomhash":"116129c32bb1d6e1450728be85528e40",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118429,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118429,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Boise De Sioux Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209023827
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -96.58944,
+    46.25444,
+    -96.58944,
+    46.25444
+],
+  "geometry": {"coordinates":[-96.58944,46.25444],"type":"Point"}
+}

--- a/data/171/311/843/1/1713118431.geojson
+++ b/data/171/311/843/1/1713118431.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118431,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-81.8828,26.6941,-81.8828,26.6941",
+    "geom:latitude":26.6941,
+    "geom:longitude":-81.8828,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"71.0",
+    "gn:asciiname":"Buccaneer Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":8,
+    "gn:elevation":"4.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7192200,
+    "gn:latitude":26.6941,
+    "gn:longitude":-81.8828,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Buccaneer Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-81.9028,26.6741,-81.8628,26.7141",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7192200
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f888794e6aca71f08a165654d499fe2c",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118431,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118431,
+    "wof:lastmodified":1588726988,
+    "wof:name":"Buccaneer Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209015721
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -81.8828,
+    26.6941,
+    -81.8828,
+    26.6941
+],
+  "geometry": {"coordinates":[-81.8828,26.6941],"type":"Point"}
+}

--- a/data/171/311/843/3/1713118433.geojson
+++ b/data/171/311/843/3/1713118433.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118433,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.36083,47.17268,-122.36083,47.17268",
+    "geom:latitude":47.17268,
+    "geom:longitude":-122.36083,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"53.0",
+    "gn:asciiname":"Canyon Terrace Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":129,
+    "gn:elevation":"132.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7713237,
+    "gn:latitude":47.17268,
+    "gn:longitude":-122.36083,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Canyon Terrace Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.38083,47.15268,-122.34083,47.19268",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087547,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7713237
+    },
+    "wof:country":"US",
+    "wof:geomhash":"02896c679b6a5a6f41bc20c6c38c5c9d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118433,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087547,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118433,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Canyon Terrace Mobile Estates",
+    "wof:parent_id":102087547,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259708281
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.36083,
+    47.17268,
+    -122.36083,
+    47.17268
+],
+  "geometry": {"coordinates":[-122.36083000000001,47.17268],"type":"Point"}
+}

--- a/data/171/311/843/5/1713118435.geojson
+++ b/data/171/311/843/5/1713118435.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118435,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-95.37667,45.88861,-95.37667,45.88861",
+    "geom:latitude":45.88861,
+    "geom:longitude":-95.37667,
+    "gn:admin1_code":"MN",
+    "gn:admin2_code":"41.0",
+    "gn:admin3_code":"928.0",
+    "gn:asciiname":"Alexandria Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":427,
+    "gn:elevation":"428.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5016113,
+    "gn:latitude":45.88861,
+    "gn:longitude":-95.37667,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Alexandria Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Chicago",
+    "iso:country":"US",
+    "lbl:bbox":"-95.39667,45.86861,-95.35667,45.90861",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102087127,
+        404513751,
+        85688727
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5016113
+    },
+    "wof:country":"US",
+    "wof:geomhash":"4db7180d5974111625f49b86ebb0f3ae",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118435,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102087127,
+            "localadmin_id":404513751,
+            "locality_id":-1,
+            "region_id":85688727
+        }
+    ],
+    "wof:id":1713118435,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Alexandria Mobile Estates",
+    "wof:parent_id":404513751,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310122289
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -95.37667,
+    45.88861,
+    -95.37667,
+    45.88861
+],
+  "geometry": {"coordinates":[-95.37667,45.88861],"type":"Point"}
+}

--- a/data/171/311/843/9/1713118439.geojson
+++ b/data/171/311/843/9/1713118439.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118439,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.66719,38.76234,-76.66719,38.76234",
+    "geom:latitude":38.76234,
+    "geom:longitude":-76.66719,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"3.0",
+    "gn:asciiname":"Lyons Creek Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":2,
+    "gn:elevation":"2.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4361420,
+    "gn:latitude":38.76234,
+    "gn:longitude":-76.66719,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Lyons Creek Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.68719,38.74234,-76.64719,38.78234",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083469,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4361420
+    },
+    "wof:country":"US",
+    "wof:geomhash":"7a329df8ccc86d929ac2d546438f82cc",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118439,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083469,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118439,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Lyons Creek Mobile Estates",
+    "wof:parent_id":102083469,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310221433
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.66719,
+    38.76234,
+    -76.66719,
+    38.76234
+],
+  "geometry": {"coordinates":[-76.66719000000001,38.76234],"type":"Point"}
+}

--- a/data/171/311/844/1/1713118441.geojson
+++ b/data/171/311/844/1/1713118441.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118441,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-123.12207,48.0812,-123.12207,48.0812",
+    "geom:latitude":48.0812,
+    "geom:longitude":-123.12207,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"9.0",
+    "gn:asciiname":"Juniper Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":69,
+    "gn:elevation":"69.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714355,
+    "gn:latitude":48.0812,
+    "gn:longitude":-123.12207,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Juniper Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-123.14207,48.0612,-123.10207,48.1012",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084229,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714355
+    },
+    "wof:country":"US",
+    "wof:geomhash":"de52d0d6d283259eafbaed8570042df2",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118441,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084229,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118441,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Juniper Mobile Estates",
+    "wof:parent_id":102084229,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310620681
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -123.12207,
+    48.0812,
+    -123.12207,
+    48.0812
+],
+  "geometry": {"coordinates":[-123.12206999999999,48.0812],"type":"Point"}
+}

--- a/data/171/311/844/3/1713118443.geojson
+++ b/data/171/311/844/3/1713118443.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118443,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-77.1497,39.35955,-77.1497,39.35955",
+    "geom:latitude":39.35955,
+    "geom:longitude":-77.1497,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"13.0",
+    "gn:asciiname":"Pheasant Ridge Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":239,
+    "gn:elevation":"240.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4365317,
+    "gn:latitude":39.35955,
+    "gn:longitude":-77.1497,
+    "gn:modification_date":"2010-02-19",
+    "gn:name":"Pheasant Ridge Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-77.1697,39.33955,-77.1297,39.37955",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082717,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4365317
+    },
+    "wof:country":"US",
+    "wof:geomhash":"d115f03d4a39204a00ed1ed06dd0fd27",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118443,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082717,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118443,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Pheasant Ridge Mobile Estates",
+    "wof:parent_id":102082717,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310623349
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -77.1497,
+    39.35955,
+    -77.1497,
+    39.35955
+],
+  "geometry": {"coordinates":[-77.1497,39.35955],"type":"Point"}
+}

--- a/data/171/311/844/5/1713118445.geojson
+++ b/data/171/311/844/5/1713118445.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118445,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.3208,27.9956,-82.3208,27.9956",
+    "geom:latitude":27.9956,
+    "geom:longitude":-82.3208,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"57",
+    "gn:asciiname":"Lake Marie Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":17,
+    "gn:elevation":"9.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7218302,
+    "gn:latitude":27.9956,
+    "gn:longitude":-82.3208,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Lake Marie Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.3408,27.9756,-82.3008,28.0156",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085773,
+        85688651
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7218302
+    },
+    "wof:country":"US",
+    "wof:geomhash":"0df65dcfd2649367cb7be4fefb78d868",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118445,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085773,
+            "locality_id":-1,
+            "region_id":85688651
+        }
+    ],
+    "wof:id":1713118445,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Lake Marie Mobile Estates",
+    "wof:parent_id":102085773,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310520823
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.3208,
+    27.9956,
+    -82.3208,
+    27.9956
+],
+  "geometry": {"coordinates":[-82.32080000000001,27.9956],"type":"Point"}
+}

--- a/data/171/311/844/7/1713118447.geojson
+++ b/data/171/311/844/7/1713118447.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118447,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-114.62704,32.67747,-114.62704,32.67747",
+    "geom:latitude":32.67747,
+    "geom:longitude":-114.62704,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"27.0",
+    "gn:asciiname":"Desert Palms Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":59,
+    "gn:elevation":"59.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7723169,
+    "gn:latitude":32.67747,
+    "gn:longitude":-114.62704,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Desert Palms Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-114.64704,32.65747,-114.60704,32.69747",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081527,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7723169
+    },
+    "wof:country":"US",
+    "wof:geomhash":"6af40aabfa80fd553e8324df3798c08a",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118447,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081527,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118447,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Desert Palms Mobile Estates",
+    "wof:parent_id":102081527,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310617317
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -114.62704,
+    32.67747,
+    -114.62704,
+    32.67747
+],
+  "geometry": {"coordinates":[-114.62703999999999,32.67747],"type":"Point"}
+}

--- a/data/171/311/844/9/1713118449.geojson
+++ b/data/171/311/844/9/1713118449.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118449,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-111.57601,35.2292,-111.57601,35.2292",
+    "geom:latitude":35.2292,
+    "geom:longitude":-111.57601,
+    "gn:admin1_code":"AZ",
+    "gn:admin2_code":"5.0",
+    "gn:asciiname":"Colony Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":2085,
+    "gn:elevation":"2085.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":8483508,
+    "gn:latitude":35.2292,
+    "gn:longitude":-111.57601,
+    "gn:modification_date":"2013-03-08",
+    "gn:name":"Colony Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Phoenix",
+    "iso:country":"US",
+    "lbl:bbox":"-111.59601,35.2092,-111.55601,35.2492",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086831,
+        85688719
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":8483508
+    },
+    "wof:country":"US",
+    "wof:geomhash":"694da8b7c7c266d76cae1520ecd0c582",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118449,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086831,
+            "locality_id":-1,
+            "region_id":85688719
+        }
+    ],
+    "wof:id":1713118449,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Colony Mobile Estates",
+    "wof:parent_id":102086831,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310616593
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -111.57601,
+    35.2292,
+    -111.57601,
+    35.2292
+],
+  "geometry": {"coordinates":[-111.57601,35.2292],"type":"Point"}
+}

--- a/data/171/311/845/1/1713118451.geojson
+++ b/data/171/311/845/1/1713118451.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118451,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-76.83136,39.11844,-76.83136,39.11844",
+    "geom:latitude":39.11844,
+    "geom:longitude":-76.83136,
+    "gn:admin1_code":"MD",
+    "gn:admin2_code":"27.0",
+    "gn:asciiname":"Beech Crest Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":78,
+    "gn:elevation":"71.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":4348216,
+    "gn:latitude":39.11844,
+    "gn:longitude":-76.83136,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Beech Crest Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-76.85136,39.09844,-76.81136,39.13844",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102084263,
+        85688501
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":4348216
+    },
+    "wof:country":"US",
+    "wof:geomhash":"67eaa3b7b4f044195e07b3d543ac2570",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118451,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102084263,
+            "locality_id":-1,
+            "region_id":85688501
+        }
+    ],
+    "wof:id":1713118451,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Beech Crest Mobile Estates",
+    "wof:parent_id":102084263,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310024977
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -76.83136,
+    39.11844,
+    -76.83136,
+    39.11844
+],
+  "geometry": {"coordinates":[-76.83136,39.11844],"type":"Point"}
+}

--- a/data/171/311/845/3/1713118453.geojson
+++ b/data/171/311/845/3/1713118453.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118453,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-119.27872,34.43527,-119.27872,34.43527",
+    "geom:latitude":34.43527,
+    "geom:longitude":-119.27872,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"111",
+    "gn:asciiname":"Golden Oaks Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":207,
+    "gn:elevation":"205.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5352891,
+    "gn:latitude":34.43527,
+    "gn:longitude":-119.27872,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Golden Oaks Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-119.29872,34.41527,-119.25872,34.45527",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102086933,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5352891
+    },
+    "wof:country":"US",
+    "wof:geomhash":"f8938bc818535d2e77454b19448a762a",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118453,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102086933,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118453,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Golden Oaks Mobile Estates",
+    "wof:parent_id":102086933,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1310635657
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -119.27872,
+    34.43527,
+    -119.27872,
+    34.43527
+],
+  "geometry": {"coordinates":[-119.27872000000001,34.43527],"type":"Point"}
+}

--- a/data/171/311/845/7/1713118457.geojson
+++ b/data/171/311/845/7/1713118457.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118457,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-73.68376,43.30441,-73.68376,43.30441",
+    "geom:latitude":43.30441,
+    "geom:longitude":-73.68376,
+    "gn:admin1_code":"NY",
+    "gn:admin2_code":"113.0",
+    "gn:admin3_code":"60356.0",
+    "gn:asciiname":"Northwinds Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":116,
+    "gn:elevation":"116.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7707078,
+    "gn:latitude":43.30441,
+    "gn:longitude":-73.68376,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Northwinds Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-73.70376,43.28441,-73.66376,43.32441",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081791,
+        404523293,
+        85688543
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7707078
+    },
+    "wof:country":"US",
+    "wof:geomhash":"631fd7c8a02605f4708fc92644739cf8",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118457,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081791,
+            "localadmin_id":404523293,
+            "locality_id":-1,
+            "region_id":85688543
+        }
+    ],
+    "wof:id":1713118457,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Northwinds Mobile Estates",
+    "wof:parent_id":404523293,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259608759
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -73.68376,
+    43.30441,
+    -73.68376,
+    43.30441
+],
+  "geometry": {"coordinates":[-73.68376000000001,43.30441],"type":"Point"}
+}

--- a/data/171/311/845/9/1713118459.geojson
+++ b/data/171/311/845/9/1713118459.geojson
@@ -1,0 +1,82 @@
+{
+  "id": 1713118459,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-106.13248,31.66706,-106.13248,31.66706",
+    "geom:latitude":31.66706,
+    "geom:longitude":-106.13248,
+    "gn:admin1_code":"TX",
+    "gn:admin2_code":"141.0",
+    "gn:asciiname":"Cochran Mobile Park Colonia",
+    "gn:country_code":"US",
+    "gn:dem":1220,
+    "gn:elevation":"1226.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5519153,
+    "gn:latitude":31.66706,
+    "gn:longitude":-106.13248,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Cochran Mobile Park Colonia",
+    "gn:population":0,
+    "gn:timezone":"America/Denver",
+    "iso:country":"US",
+    "lbl:bbox":"-106.15248,31.64706,-106.11248,31.68706",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Cochran Mobile Park Colonia"
+    ],
+    "name:und_x_variant":[
+        "Cochran Estates Colonia"
+    ],
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085989,
+        85688753
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5519153
+    },
+    "wof:country":"US",
+    "wof:geomhash":"e0864914615738fc0bf7ca6a15ee8e1b",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118459,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085989,
+            "locality_id":-1,
+            "region_id":85688753
+        }
+    ],
+    "wof:id":1713118459,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Cochran Mobile Park Colonia",
+    "wof:parent_id":102085989,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1259717803
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -106.13248,
+    31.66706,
+    -106.13248,
+    31.66706
+],
+  "geometry": {"coordinates":[-106.13248,31.66706],"type":"Point"}
+}

--- a/data/171/311/846/1/1713118461.geojson
+++ b/data/171/311/846/1/1713118461.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118461,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-80.1143,26.6323,-80.1143,26.6323",
+    "geom:latitude":26.6323,
+    "geom:longitude":-80.1143,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"99.0",
+    "gn:asciiname":"Green Acres Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":10,
+    "gn:elevation":"5.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7191411,
+    "gn:latitude":26.6323,
+    "gn:longitude":-80.1143,
+    "gn:modification_date":"2010-02-05",
+    "gn:name":"Green Acres Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-80.1343,26.6123,-80.0943,26.6523",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7191411
+    },
+    "wof:country":"US",
+    "wof:geomhash":"1d57aa6aaa052ef339a87a7f180754f1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118461,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118461,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Green Acres Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209631733
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -80.1143,
+    26.6323,
+    -80.1143,
+    26.6323
+],
+  "geometry": {"coordinates":[-80.1143,26.6323],"type":"Point"}
+}

--- a/data/171/311/846/3/1713118463.geojson
+++ b/data/171/311/846/3/1713118463.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118463,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-105.8375,46.4125,-105.8375,46.4125",
+    "geom:latitude":46.4125,
+    "geom:longitude":-105.8375,
+    "gn:admin1_code":"MT",
+    "gn:admin2_code":"17.0",
+    "gn:asciiname":"Westwood Estates",
+    "gn:country_code":"US",
+    "gn:dem":719,
+    "gn:elevation":"720.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":5685840,
+    "gn:latitude":46.4125,
+    "gn:longitude":-105.8375,
+    "gn:modification_date":"2006-01-15",
+    "gn:name":"Westwood Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Denver",
+    "iso:country":"US",
+    "lbl:bbox":"-105.8575,46.3925,-105.8175,46.4325",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Westwood Estates"
+    ],
+    "name:und_x_variant":[
+        "Albert Mobile Home Park"
+    ],
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":5685840
+    },
+    "wof:country":"US",
+    "wof:geomhash":"2bb45cc1963af90da444db8ac8bd7229",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118463,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118463,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Westwood Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209122463
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -105.8375,
+    46.4125,
+    -105.8375,
+    46.4125
+],
+  "geometry": {"coordinates":[-105.83750000000001,46.4125],"type":"Point"}
+}

--- a/data/171/311/846/5/1713118465.geojson
+++ b/data/171/311/846/5/1713118465.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118465,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-123.13671,47.24567,-123.13671,47.24567",
+    "geom:latitude":47.24567,
+    "geom:longitude":-123.13671,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"45.0",
+    "gn:asciiname":"Evergreen Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":83,
+    "gn:elevation":"85.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714361,
+    "gn:latitude":47.24567,
+    "gn:longitude":-123.13671,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Evergreen Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-123.15671,47.22567,-123.11671,47.26567",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714361
+    },
+    "wof:country":"US",
+    "wof:geomhash":"02e2f659f6cc56ddc10691df561478d1",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118465,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118465,
+    "wof:lastmodified":1588726989,
+    "wof:name":"Evergreen Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209639839
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -123.13671,
+    47.24567,
+    -123.13671,
+    47.24567
+],
+  "geometry": {"coordinates":[-123.13670999999999,47.24567],"type":"Point"}
+}

--- a/data/171/311/846/7/1713118467.geojson
+++ b/data/171/311/846/7/1713118467.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118467,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-122.61023,47.6226,-122.61023,47.6226",
+    "geom:latitude":47.6226,
+    "geom:longitude":-122.61023,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"35.0",
+    "gn:asciiname":"Kariotis Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":120,
+    "gn:elevation":"121.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714032,
+    "gn:latitude":47.6226,
+    "gn:longitude":-122.61023,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Kariotis Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-122.63023,47.6026,-122.59023,47.6426",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714032
+    },
+    "wof:country":"US",
+    "wof:geomhash":"af1b33cd19bc9bbc090aa7076b93af52",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118467,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118467,
+    "wof:lastmodified":1588726990,
+    "wof:name":"Kariotis Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209430837
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -122.61023,
+    47.6226,
+    -122.61023,
+    47.6226
+],
+  "geometry": {"coordinates":[-122.61023,47.6226],"type":"Point"}
+}

--- a/data/171/311/846/9/1713118469.geojson
+++ b/data/171/311/846/9/1713118469.geojson
@@ -1,0 +1,70 @@
+{
+  "id": 1713118469,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.3159,27.9946,-82.3159,27.9946",
+    "geom:latitude":27.9946,
+    "geom:longitude":-82.3159,
+    "gn:admin1_code":"FL",
+    "gn:admin2_code":"57",
+    "gn:asciiname":"East Gate Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":17,
+    "gn:elevation":"10.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7216891,
+    "gn:latitude":27.9946,
+    "gn:longitude":-82.3159,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"East Gate Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.3359,27.9746,-82.2959,28.0146",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        85633793
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7216891
+    },
+    "wof:country":"US",
+    "wof:geomhash":"abd5bcca95089bb63b716809f01b7f6c",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118469,
+            "country_id":85633793,
+            "locality_id":-1
+        }
+    ],
+    "wof:id":1713118469,
+    "wof:lastmodified":1588726990,
+    "wof:name":"East Gate Mobile Estates",
+    "wof:parent_id":85633793,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1209434603
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.3159,
+    27.9946,
+    -82.3159,
+    27.9946
+],
+  "geometry": {"coordinates":[-82.3159,27.9946],"type":"Point"}
+}

--- a/data/171/311/847/1/1713118471.geojson
+++ b/data/171/311/847/1/1713118471.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118471,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-121.73806,38.54222,-121.73806,38.54222",
+    "geom:latitude":38.54222,
+    "geom:longitude":-121.73806,
+    "gn:admin1_code":"CA",
+    "gn:admin2_code":"113",
+    "gn:asciiname":"Davis Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":14,
+    "gn:elevation":"16.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7231903,
+    "gn:latitude":38.54222,
+    "gn:longitude":-121.73806,
+    "gn:modification_date":"2010-02-06",
+    "gn:name":"Davis Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-121.75806,38.52222,-121.71806,38.56222",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102082309,
+        85688637
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7231903
+    },
+    "wof:country":"US",
+    "wof:geomhash":"5a4f351e8b0597574655c7b3b64d3d6f",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118471,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102082309,
+            "locality_id":-1,
+            "region_id":85688637
+        }
+    ],
+    "wof:id":1713118471,
+    "wof:lastmodified":1588726990,
+    "wof:name":"Davis Mobile Estates",
+    "wof:parent_id":102082309,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1193172209
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -121.73806,
+    38.54222,
+    -121.73806,
+    38.54222
+],
+  "geometry": {"coordinates":[-121.73806,38.54222],"type":"Point"}
+}

--- a/data/171/311/847/5/1713118475.geojson
+++ b/data/171/311/847/5/1713118475.geojson
@@ -1,0 +1,79 @@
+{
+  "id": 1713118475,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-82.65917,40.95889,-82.65917,40.95889",
+    "geom:latitude":40.95889,
+    "geom:longitude":-82.65917,
+    "gn:admin1_code":"OH",
+    "gn:admin2_code":"139",
+    "gn:admin3_code":"63814.0",
+    "gn:asciiname":"Pine Grove Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":329,
+    "gn:elevation":"331.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7235459,
+    "gn:latitude":40.95889,
+    "gn:longitude":-82.65917,
+    "gn:modification_date":"2017-05-23",
+    "gn:name":"Pine Grove Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/New_York",
+    "iso:country":"US",
+    "lbl:bbox":"-82.67917,40.93889,-82.63917,40.97889",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102083681,
+        404525921,
+        85688485
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7235459
+    },
+    "wof:country":"US",
+    "wof:geomhash":"e0ded1f2e7cf08ac860f653db393ab87",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118475,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102083681,
+            "localadmin_id":404525921,
+            "locality_id":-1,
+            "region_id":85688485
+        }
+    ],
+    "wof:id":1713118475,
+    "wof:lastmodified":1588726990,
+    "wof:name":"Pine Grove Mobile Estates",
+    "wof:parent_id":404525921,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1193035703
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -82.65917,
+    40.95889,
+    -82.65917,
+    40.95889
+],
+  "geometry": {"coordinates":[-82.65917,40.95889],"type":"Point"}
+}

--- a/data/171/311/847/7/1713118477.geojson
+++ b/data/171/311/847/7/1713118477.geojson
@@ -1,0 +1,76 @@
+{
+  "id": 1713118477,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-117.87441,48.45318,-117.87441,48.45318",
+    "geom:latitude":48.45318,
+    "geom:longitude":-117.87441,
+    "gn:admin1_code":"WA",
+    "gn:admin2_code":"65.0",
+    "gn:asciiname":"Country Villa Mobile Estates",
+    "gn:country_code":"US",
+    "gn:dem":488,
+    "gn:elevation":"488.0",
+    "gn:feature_class":"P",
+    "gn:feature_code":"PPL",
+    "gn:geonameid":7714057,
+    "gn:latitude":48.45318,
+    "gn:longitude":-117.87441,
+    "gn:modification_date":"2011-03-12",
+    "gn:name":"Country Villa Mobile Estates",
+    "gn:population":0,
+    "gn:timezone":"America/Los_Angeles",
+    "iso:country":"US",
+    "lbl:bbox":"-117.89441,48.43318,-117.85441,48.47318",
+    "lbl:max_zoom":18.0,
+    "lbl:min_zoom":13.5,
+    "mz:hierarchy_label":1,
+    "mz:is_current":-1,
+    "mz:min_zoom":12.0,
+    "src:geom":"geonames",
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085373,
+        85688623
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{
+        "gn:id":7714057
+    },
+    "wof:country":"US",
+    "wof:geomhash":"96a06ab47cc424b15540f3687abb668d",
+    "wof:hierarchy":[
+        {
+            "campus_id":1713118477,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085373,
+            "locality_id":-1,
+            "region_id":85688623
+        }
+    ],
+    "wof:id":1713118477,
+    "wof:lastmodified":1588726990,
+    "wof:name":"Country Villa Mobile Estates",
+    "wof:parent_id":102085373,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1193147981
+    ],
+    "wof:tags":[]
+},
+  "bbox": [
+    -117.87441,
+    48.45318,
+    -117.87441,
+    48.45318
+],
+  "geometry": {"coordinates":[-117.87441,48.45318],"type":"Point"}
+}

--- a/data/859/261/51/85926151.geojson
+++ b/data/859/261/51/85926151.geojson
@@ -23,7 +23,7 @@
         "\u067e\u0627\u06cc\u0646 \u06a9\u0627\u0646\u06cc\u0648\u0646"
     ],
     "name:ceb_x_preferred":[
-        "Pine Canyon Mobile Estates"
+        "Pine Canyon"
     ],
     "name:deu_x_preferred":[
         "Pine Canyon"
@@ -85,8 +85,8 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688637,
-        102080859
+        102080859,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -105,7 +105,7 @@
         }
     ],
     "wof:id":85926151,
-    "wof:lastmodified":1566612195,
+    "wof:lastmodified":1588724046,
     "wof:name":"Pine Canyon",
     "wof:parent_id":102080859,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes an edge case that wasn't caught in https://github.com/whosonfirst-data/whosonfirst-data/issues/1431.

This PR moves "[Mobile Estates](https://spelunker.whosonfirst.org/search/?q=mobile+estates&placetype=locality)" locality records to campuses. The update process should be identical to what was done through #1431.

Superseding, PIP work, placetype swapping, and property flag updates should all be included. In one case, a bunk "Mobile Estates" name property value was updated (this commit: https://github.com/whosonfirst-data/whosonfirst-data-admin-us/commit/efee6695246c5ae8a9f8f64fb44d02e6f157ef4d)

This can be merged once approved.