### PR TITLE
Clean up shortcodes on NYC counties

### DIFF
--- a/data/102/081/779/102081779.geojson
+++ b/data/102/081/779/102081779.geojson
@@ -215,7 +215,7 @@
     ],
     "wof:id":102081779,
     "wof:label":"Richmond County",
-    "wof:lastmodified":1566609779,
+    "wof:lastmodified":1588977310,
     "wof:name":"Richmond",
     "wof:parent_id":85688543,
     "wof:placetype":"county",
@@ -223,7 +223,6 @@
     "wof:population":468730,
     "wof:population_rank":10,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:shortcode":"RI",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]

--- a/data/102/081/863/102081863.geojson
+++ b/data/102/081/863/102081863.geojson
@@ -119,7 +119,7 @@
     ],
     "wof:id":102081863,
     "wof:label":"New York County",
-    "wof:lastmodified":1566609844,
+    "wof:lastmodified":1588977315,
     "wof:name":"New York",
     "wof:parent_id":85688543,
     "wof:placetype":"county",
@@ -127,7 +127,6 @@
     "wof:population":1585873,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:shortcode":"NE",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]

--- a/data/102/082/361/102082361.geojson
+++ b/data/102/082/361/102082361.geojson
@@ -112,7 +112,7 @@
     ],
     "wof:id":102082361,
     "wof:label":"Kings County",
-    "wof:lastmodified":1566609251,
+    "wof:lastmodified":1588977321,
     "wof:name":"Kings",
     "wof:parent_id":85688543,
     "wof:placetype":"county",
@@ -120,7 +120,7 @@
     "wof:population":2504700,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:shortcode":"KI",
+    "wof:shortcode":"BK",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]

--- a/data/102/082/377/102082377.geojson
+++ b/data/102/082/377/102082377.geojson
@@ -330,7 +330,7 @@
     ],
     "wof:id":102082377,
     "wof:label":"Queens County",
-    "wof:lastmodified":1566609236,
+    "wof:lastmodified":1588977325,
     "wof:name":"Queens",
     "wof:parent_id":85688543,
     "wof:placetype":"county",
@@ -338,7 +338,6 @@
     "wof:population":2230722,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:shortcode":"QU",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]

--- a/data/102/083/063/102083063.geojson
+++ b/data/102/083/063/102083063.geojson
@@ -318,7 +318,7 @@
     ],
     "wof:id":102083063,
     "wof:label":"Bronx County",
-    "wof:lastmodified":1566608679,
+    "wof:lastmodified":1588977329,
     "wof:name":"Bronx",
     "wof:parent_id":85688543,
     "wof:placetype":"county",
@@ -326,7 +326,7 @@
     "wof:population":1385108,
     "wof:population_rank":12,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:shortcode":"BN",
+    "wof:shortcode":"BX",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]


### PR DESCRIPTION
Will replace https://github.com/whosonfirst-data/whosonfirst-data-admin-us/pull/51

This adjusts `wof:shortcode` properties in NYC counties, per feedback in that PR. No need to PIP, can merge once approved.