### PR TITLE
Standardize on unknown source

### DIFF
--- a/data/102/524/817/102524817.geojson
+++ b/data/102/524/817/102524817.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u043e\u043b\u043a\u0438\u043d"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":302,
     "woe:hierarchy":{
@@ -48,7 +48,7 @@
         "icao:code":"KZEF"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102524817,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102524817,
-    "wof:lastmodified":1566610065,
+    "wof:lastmodified":1589219004,
     "wof:name":"Elkin Municipal Airport",
     "wof:parent_id":85688773,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/023/102525023.geojson
+++ b/data/102/525/023/102525023.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043e\u043b\u043a\u043e\u0440\u0442-\u043c\u0443\u0440\u0442\u0443\u043d \u043a\u043e\u0432\u043d\u0442\u0438"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":235,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KEHA"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525023,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102525023,
-    "wof:lastmodified":1566610046,
+    "wof:lastmodified":1589219004,
     "wof:name":"Elkhart-Morton County Airport",
     "wof:parent_id":85945937,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/059/102525059.geojson
+++ b/data/102/525/059/102525059.geojson
@@ -24,7 +24,7 @@
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0645\u0627\u0648\u0646\u062a \u0648\u0631\u0646\u0646"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":163,
     "woe:hierarchy":{
@@ -47,7 +47,7 @@
         "icao:code":"KMVN"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525059,
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":102525059,
-    "wof:lastmodified":1566610055,
+    "wof:lastmodified":1589219004,
     "wof:name":"Mount Vernon Outland Airport",
     "wof:parent_id":85939323,
     "wof:placetype":"campus",
@@ -75,5 +75,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/107/102525107.geojson
+++ b/data/102/525/107/102525107.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043c\u0443\u0437\u0438\u0437 \u043f\u0443\u0438\u043d\u0442"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":245,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KMUT"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525107,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102525107,
-    "wof:lastmodified":1566610052,
+    "wof:lastmodified":1589219004,
     "wof:name":"Muscatine Municipal Airport",
     "wof:parent_id":85944863,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/113/102525113.geojson
+++ b/data/102/525/113/102525113.geojson
@@ -21,7 +21,7 @@
         "EOS",
         "KEOS"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "icao:code":"KEOS"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525113,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102525113,
-    "wof:lastmodified":1566610058,
+    "wof:lastmodified":1589219004,
     "wof:name":"Neosho Memorial Airport",
     "wof:parent_id":85971307,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/163/102525163.geojson
+++ b/data/102/525/163/102525163.geojson
@@ -21,7 +21,7 @@
         "MOP",
         "KMOP"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "icao:code":"KMOP"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525163,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102525163,
-    "wof:lastmodified":1566610052,
+    "wof:lastmodified":1589219004,
     "wof:name":"Mt Pleasant Municipal Airport",
     "wof:parent_id":85943681,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/173/102525173.geojson
+++ b/data/102/525/173/102525173.geojson
@@ -27,7 +27,7 @@
         "Muir AAF"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -51,7 +51,7 @@
         "icao:code":"KMUI"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525173,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102525173,
-    "wof:lastmodified":1566610049,
+    "wof:lastmodified":1589219004,
     "wof:name":"Muir Army Air Field",
     "wof:parent_id":85826915,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/213/102525213.geojson
+++ b/data/102/525/213/102525213.geojson
@@ -66,7 +66,7 @@
         "Mountain Home Air Force Base CDP"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "src:population":"geonames",
     "woe:hierarchy":{
@@ -92,7 +92,7 @@
         "wk:page":"Mountain Home Air Force Base"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525213,
@@ -103,7 +103,7 @@
         }
     ],
     "wof:id":102525213,
-    "wof:lastmodified":1566610055,
+    "wof:lastmodified":1589219004,
     "wof:name":"Mountain Home Air Force Base",
     "wof:parent_id":85938211,
     "wof:placetype":"campus",
@@ -122,5 +122,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/385/102525385.geojson
+++ b/data/102/525/385/102525385.geojson
@@ -21,7 +21,7 @@
         "PIM",
         "KPIM"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -44,7 +44,7 @@
         "icao:code":"KPIM"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525385,
@@ -56,7 +56,7 @@
         }
     ],
     "wof:id":102525385,
-    "wof:lastmodified":1566610050,
+    "wof:lastmodified":1589219004,
     "wof:name":"Callaway Gardens-Harris County Airport",
     "wof:parent_id":85835873,
     "wof:placetype":"campus",
@@ -73,5 +73,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/557/102525557.geojson
+++ b/data/102/525/557/102525557.geojson
@@ -108,7 +108,7 @@
     "name:zho_x_preferred":[
         "\u5361\u7eb3\u7ef4\u62c9\u5c14\u89d2\u7a7a\u519b\u57fa\u5730"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":2870,
     "woe:hierarchy":{
@@ -129,7 +129,7 @@
         "icao:code":"KXMR"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525557,
@@ -138,7 +138,7 @@
         }
     ],
     "wof:id":102525557,
-    "wof:lastmodified":1566610045,
+    "wof:lastmodified":1589219004,
     "wof:name":"Cape Canaveral Air Force Station",
     "wof:parent_id":85688651,
     "wof:placetype":"campus",
@@ -155,5 +155,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/731/102525731.geojson
+++ b/data/102/525/731/102525731.geojson
@@ -25,7 +25,7 @@
         "KMKO"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -48,7 +48,7 @@
         "icao:code":"KMKO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525731,
@@ -59,7 +59,7 @@
         }
     ],
     "wof:id":102525731,
-    "wof:lastmodified":1566610046,
+    "wof:lastmodified":1589219004,
     "wof:name":"Davis Field Airport",
     "wof:parent_id":101715429,
     "wof:placetype":"campus",
@@ -76,5 +76,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/791/102525791.geojson
+++ b/data/102/525/791/102525791.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0434\u043e\u0440\u043a \u043a\u043e\u043d"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":325,
     "woe:hierarchy":{
@@ -48,7 +48,7 @@
         "icao:code":"KVES"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525791,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102525791,
-    "wof:lastmodified":1566610045,
+    "wof:lastmodified":1589219004,
     "wof:name":"Darke County Airport",
     "wof:parent_id":85688485,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/525/955/102525955.geojson
+++ b/data/102/525/955/102525955.geojson
@@ -21,7 +21,7 @@
         "HTW",
         "KHTW"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":861,
     "woe:hierarchy":{
@@ -45,7 +45,7 @@
         "icao:code":"KHTW"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102525955,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102525955,
-    "wof:lastmodified":1566610046,
+    "wof:lastmodified":1589219004,
     "wof:name":"Lawrence County Airpark",
     "wof:parent_id":85868315,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/526/207/102526207.geojson
+++ b/data/102/526/207/102526207.geojson
@@ -21,7 +21,7 @@
         "LKR",
         "KLKR"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -41,7 +41,7 @@
         "icao:code":"KLKR"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102526207,
@@ -50,7 +50,7 @@
         }
     ],
     "wof:id":102526207,
-    "wof:lastmodified":1566609372,
+    "wof:lastmodified":1589219002,
     "wof:name":"Lancaster County-Mcwhirter Field Airport",
     "wof:parent_id":85688683,
     "wof:placetype":"campus",
@@ -67,5 +67,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/526/395/102526395.geojson
+++ b/data/102/526/395/102526395.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043a\u04ef\u0444\u04e3 \u043a\u043e\u0432\u043d\u0442\u0438"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":218,
     "woe:hierarchy":{
@@ -48,7 +48,7 @@
         "icao:code":"KUKL"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102526395,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102526395,
-    "wof:lastmodified":1566609368,
+    "wof:lastmodified":1589219002,
     "wof:name":"Coffey County Airport",
     "wof:parent_id":85688555,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/526/473/102526473.geojson
+++ b/data/102/526/473/102526473.geojson
@@ -21,7 +21,7 @@
         "OLU",
         "KOLU"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":75,
     "woe:hierarchy":{
@@ -44,7 +44,7 @@
         "icao:code":"KOLU"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102526473,
@@ -55,7 +55,7 @@
         }
     ],
     "wof:id":102526473,
-    "wof:lastmodified":1566609371,
+    "wof:lastmodified":1589219002,
     "wof:name":"Columbus Municipal Airport",
     "wof:parent_id":85974401,
     "wof:placetype":"campus",
@@ -72,5 +72,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/526/517/102526517.geojson
+++ b/data/102/526/517/102526517.geojson
@@ -21,7 +21,7 @@
         "RYY",
         "KRYY"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -44,7 +44,7 @@
         "icao:code":"KRYY"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102526517,
@@ -56,7 +56,7 @@
         }
     ],
     "wof:id":102526517,
-    "wof:lastmodified":1566609367,
+    "wof:lastmodified":1589219002,
     "wof:name":"Cobb County Airport-Mccollum Field",
     "wof:parent_id":85837407,
     "wof:placetype":"campus",
@@ -73,5 +73,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/526/663/102526663.geojson
+++ b/data/102/526/663/102526663.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043c\u0430\u04b3\u0430\u043b \u0448\u0443\u043b\u200c\u0431\u200c\u0448\u0430\u04b3\u0440\u0438\u0441\u0442\u043e\u043d \u043a\u043b\u044e\u043b\u043d\u0434"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -49,7 +49,7 @@
         "icao:code":"KEHO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102526663,
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":102526663,
-    "wof:lastmodified":1566609372,
+    "wof:lastmodified":1589219002,
     "wof:name":"Shelby Municipal Airport",
     "wof:parent_id":85980967,
     "wof:placetype":"campus",
@@ -77,5 +77,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/526/687/102526687.geojson
+++ b/data/102/526/687/102526687.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0448\u0430\u0440"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":270,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KSWI"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102526687,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102526687,
-    "wof:lastmodified":1566609365,
+    "wof:lastmodified":1589219002,
     "wof:name":"Sherman Municipal Airport",
     "wof:parent_id":101725053,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/526/967/102526967.geojson
+++ b/data/102/526/967/102526967.geojson
@@ -21,7 +21,7 @@
         "TRX",
         "KTRX"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":33,
     "woe:hierarchy":{
@@ -44,7 +44,7 @@
         "icao:code":"KTRX"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102526967,
@@ -55,7 +55,7 @@
         }
     ],
     "wof:id":102526967,
-    "wof:lastmodified":1566609369,
+    "wof:lastmodified":1589219002,
     "wof:name":"Trenton Municipal Airport",
     "wof:parent_id":85971667,
     "wof:placetype":"campus",
@@ -72,5 +72,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/526/987/102526987.geojson
+++ b/data/102/526/987/102526987.geojson
@@ -21,7 +21,7 @@
         "TOR",
         "KTOR"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":284,
     "woe:hierarchy":{
@@ -45,7 +45,7 @@
         "icao:code":"KTOR"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102526987,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102526987,
-    "wof:lastmodified":1566609374,
+    "wof:lastmodified":1589219002,
     "wof:name":"Torrington Municipal Airport",
     "wof:parent_id":85850153,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/527/079/102527079.geojson
+++ b/data/102/527/079/102527079.geojson
@@ -24,7 +24,7 @@
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0645\u0646\u0637\u0642\u0647\u200c\u0627\u06cc \u0646\u0648\u0631\u062b\u200c\u0648\u0633\u062a"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":353,
     "woe:hierarchy":{
@@ -45,7 +45,7 @@
         "icao:code":"KEVU"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102527079,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102527079,
-    "wof:lastmodified":1566609379,
+    "wof:lastmodified":1589219002,
     "wof:name":"Maryville Memorial Airport",
     "wof:parent_id":85688661,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/527/493/102527493.geojson
+++ b/data/102/527/493/102527493.geojson
@@ -22,7 +22,7 @@
         "SSM",
         "KANJ"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -44,7 +44,7 @@
         "icao:code":"KANJ"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102527493,
@@ -55,7 +55,7 @@
         }
     ],
     "wof:id":102527493,
-    "wof:lastmodified":1566609389,
+    "wof:lastmodified":1589219002,
     "wof:name":"Sault Sainte Marie County Airport",
     "wof:parent_id":85950967,
     "wof:placetype":"campus",
@@ -72,5 +72,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/527/545/102527545.geojson
+++ b/data/102/527/545/102527545.geojson
@@ -34,7 +34,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0411\u043b\u0435\u043a \u0420\u043e\u043a"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":292,
     "woe:hierarchy":{
@@ -59,7 +59,7 @@
         "wk:page":"Black Rock Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102527545,
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":102527545,
-    "wof:lastmodified":1566609384,
+    "wof:lastmodified":1589219002,
     "wof:name":"Black Rock Airport",
     "wof:parent_id":85977461,
     "wof:placetype":"campus",
@@ -87,5 +87,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/527/749/102527749.geojson
+++ b/data/102/527/749/102527749.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u044e\u043d\u044e\u0440\u0441\u0438\u0442\u0438 \u043e\u043a\u0441\u0444\u0443\u0440\u0434"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":293,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KUOX"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102527749,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102527749,
-    "wof:lastmodified":1566609383,
+    "wof:lastmodified":1589219002,
     "wof:name":"University-Oxford Airport",
     "wof:parent_id":85834727,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/527/753/102527753.geojson
+++ b/data/102/527/753/102527753.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u044e\u043a\u0438\u043e"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":265,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KUKI"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102527753,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102527753,
-    "wof:lastmodified":1566609378,
+    "wof:lastmodified":1589219002,
     "wof:name":"Ukiah Municipal Airport",
     "wof:parent_id":85888155,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/527/777/102527777.geojson
+++ b/data/102/527/777/102527777.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0432\u0438\u043d\u0435\u0437"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":492,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KVNC"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102527777,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102527777,
-    "wof:lastmodified":1566609385,
+    "wof:lastmodified":1589219002,
     "wof:name":"Venice Municipal Airport",
     "wof:parent_id":85816997,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/527/981/102527981.geojson
+++ b/data/102/527/981/102527981.geojson
@@ -25,7 +25,7 @@
         "KRIU"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":207,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "wk:page":"Rancho Murieta Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102527981,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102527981,
-    "wof:lastmodified":1566609393,
+    "wof:lastmodified":1589219002,
     "wof:name":"Rancho Murieta Airport",
     "wof:parent_id":85926883,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/528/047/102528047.geojson
+++ b/data/102/528/047/102528047.geojson
@@ -21,7 +21,7 @@
         "RID",
         "KRID"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":231,
     "woe:hierarchy":{
@@ -44,7 +44,7 @@
         "icao:code":"KRID"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102528047,
@@ -55,7 +55,7 @@
         }
     ],
     "wof:id":102528047,
-    "wof:lastmodified":1566609349,
+    "wof:lastmodified":1589219002,
     "wof:name":"Richmond Municipal Airport",
     "wof:parent_id":85941877,
     "wof:placetype":"campus",
@@ -72,5 +72,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/528/163/102528163.geojson
+++ b/data/102/528/163/102528163.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0440\u0430\u0434 \u043e\u0432\u043a"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":313,
     "woe:hierarchy":{
@@ -48,7 +48,7 @@
         "icao:code":"KRDK"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102528163,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102528163,
-    "wof:lastmodified":1566609355,
+    "wof:lastmodified":1589219002,
     "wof:name":"Red Oak Municipal Airport",
     "wof:parent_id":85688713,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/528/341/102528341.geojson
+++ b/data/102/528/341/102528341.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0433\u043b\u043d\u0434\u0438\u043b"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":337,
     "woe:hierarchy":{
@@ -52,7 +52,7 @@
         "icao:code":"KGEU"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102528341,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":102528341,
-    "wof:lastmodified":1566609352,
+    "wof:lastmodified":1589219002,
     "wof:name":"Glendale Municipal Airport",
     "wof:parent_id":85877835,
     "wof:placetype":"campus",
@@ -81,5 +81,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/528/349/102528349.geojson
+++ b/data/102/528/349/102528349.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0433\u0440\u043d\u0434 \u043f\u0440\u0438\u0440\u0438"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":261,
     "woe:hierarchy":{
@@ -52,7 +52,7 @@
         "icao:code":"KGPM"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102528349,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":102528349,
-    "wof:lastmodified":1566609352,
+    "wof:lastmodified":1589219002,
     "wof:name":"Grand Prairie Municipal Airport",
     "wof:parent_id":85873085,
     "wof:placetype":"campus",
@@ -81,5 +81,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/528/473/102528473.geojson
+++ b/data/102/528/473/102528473.geojson
@@ -31,7 +31,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0444\u043b\u0431\u043e\u0431"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":314,
     "woe:hierarchy":{
@@ -58,7 +58,7 @@
         "wk:page":"Flabob Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102528473,
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":102528473,
-    "wof:lastmodified":1566609357,
+    "wof:lastmodified":1589219002,
     "wof:name":"Flabob Airport",
     "wof:parent_id":85873349,
     "wof:placetype":"campus",
@@ -87,5 +87,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/199/102529199.geojson
+++ b/data/102/529/199/102529199.geojson
@@ -34,7 +34,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043e\u043b\u0431\u0438\u0440\u0442 \u0432\u04b3\u0438\u0442\u0434"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":2143,
     "woe:hierarchy":{
@@ -61,7 +61,7 @@
         "wk:page":"Albert Whitted Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529199,
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":102529199,
-    "wof:lastmodified":1566609402,
+    "wof:lastmodified":1589219003,
     "wof:name":"Albert Whitted Airport",
     "wof:parent_id":85880555,
     "wof:placetype":"campus",
@@ -90,5 +90,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/369/102529369.geojson
+++ b/data/102/529/369/102529369.geojson
@@ -21,7 +21,7 @@
         "FFC",
         "KFFC"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -44,7 +44,7 @@
         "icao:code":"KFFC"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529369,
@@ -56,7 +56,7 @@
         }
     ],
     "wof:id":102529369,
-    "wof:lastmodified":1566609402,
+    "wof:lastmodified":1589219003,
     "wof:name":"Peachtree City Airport-Falcon Field",
     "wof:parent_id":85890039,
     "wof:placetype":"campus",
@@ -73,5 +73,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/465/102529465.geojson
+++ b/data/102/529/465/102529465.geojson
@@ -21,7 +21,7 @@
         "PXE",
         "KPXE"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "icao:code":"KPXE"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529465,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102529465,
-    "wof:lastmodified":1566609399,
+    "wof:lastmodified":1589219003,
     "wof:name":"Perry Fort Valley Airport",
     "wof:parent_id":85936247,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/501/102529501.geojson
+++ b/data/102/529/501/102529501.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043f\u0440\u0441\u0443\u043d \u043a\u043e\u043d"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":335,
     "woe:hierarchy":{
@@ -48,7 +48,7 @@
         "icao:code":"KTDF"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529501,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102529501,
-    "wof:lastmodified":1566609401,
+    "wof:lastmodified":1589219003,
     "wof:name":"Person County Airport",
     "wof:parent_id":85688773,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/523/102529523.geojson
+++ b/data/102/529/523/102529523.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0428\u0430\u04b3\u0440\u0435 \u0444\u0435\u043b\u0435\u043f \u0431\u0438\u043b\u043e\u0440\u0434"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":232,
     "woe:hierarchy":{
@@ -52,7 +52,7 @@
         "icao:code":"KTOP"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529523,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":102529523,
-    "wof:lastmodified":1566609409,
+    "wof:lastmodified":1589219003,
     "wof:name":"Philip Billard Municipal Airport",
     "wof:parent_id":85838959,
     "wof:placetype":"campus",
@@ -81,5 +81,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/533/102529533.geojson
+++ b/data/102/529/533/102529533.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043f\u043d \u0438\u043e\u043d"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":361,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KPEO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529533,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102529533,
-    "wof:lastmodified":1566609394,
+    "wof:lastmodified":1589219002,
     "wof:name":"Penn Yan Airport",
     "wof:parent_id":85828025,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/731/102529731.geojson
+++ b/data/102/529/731/102529731.geojson
@@ -30,7 +30,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u044d\u0451\u043b\u0430\u0442 \u043e\u0432\u0440\u0443\u0440\u043e"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":542,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KUAO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529731,
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":102529731,
-    "wof:lastmodified":1566609395,
+    "wof:lastmodified":1589219002,
     "wof:name":"Aurora State Airport",
     "wof:parent_id":85688513,
     "wof:placetype":"campus",
@@ -77,5 +77,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/811/102529811.geojson
+++ b/data/102/529/811/102529811.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u04b3\u043e\u0440\u0438\u043c\u043e\u043d-\u04b3\u0430\u0441\u0442\u0430\u043d\u0434-\u0432\u0438\u0441\u0442"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":243,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KAQW"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529811,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102529811,
-    "wof:lastmodified":1566609396,
+    "wof:lastmodified":1589219003,
     "wof:name":"Harriman and West Airport",
     "wof:parent_id":85823203,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/529/907/102529907.geojson
+++ b/data/102/529/907/102529907.geojson
@@ -21,7 +21,7 @@
         "HDI",
         "KHDI"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -44,7 +44,7 @@
         "icao:code":"KHDI"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102529907,
@@ -56,7 +56,7 @@
         }
     ],
     "wof:id":102529907,
-    "wof:lastmodified":1566609393,
+    "wof:lastmodified":1589219002,
     "wof:name":"Hardwick Field Airport",
     "wof:parent_id":85818697,
     "wof:placetype":"campus",
@@ -73,5 +73,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/041/102530041.geojson
+++ b/data/102/530/041/102530041.geojson
@@ -35,7 +35,7 @@
     "name:urd_x_preferred":[
         "\u0646\u0679 \u0679\u0631\u06cc \u06c1\u0648\u0627\u0626\u06cc \u0627\u0688\u0627"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":292,
     "woe:hierarchy":{
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":102530041,
-    "wof:lastmodified":1566609412,
+    "wof:lastmodified":1589219003,
     "wof:name":"Nut Tree Airport",
     "wof:parent_id":85830235,
     "wof:placetype":"campus",

--- a/data/102/530/053/102530053.geojson
+++ b/data/102/530/053/102530053.geojson
@@ -35,7 +35,7 @@
         "Aeroporto do Nordeste de Filad\u00e9lfia"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":895,
     "woe:hierarchy":{
@@ -62,7 +62,7 @@
         "wk:page":"Northeast Philadelphia Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530053,
@@ -74,7 +74,7 @@
         }
     ],
     "wof:id":102530053,
-    "wof:lastmodified":1566609414,
+    "wof:lastmodified":1589219003,
     "wof:name":"Northeast Philadelphia Airport",
     "wof:parent_id":85803091,
     "wof:placetype":"campus",
@@ -91,5 +91,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/087/102530087.geojson
+++ b/data/102/530/087/102530087.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043e\u0432\u0433\u0434\u043d-\u04b3\u0438\u043d\u043a\u043b\u0438"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":596,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KOGD"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530087,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102530087,
-    "wof:lastmodified":1566609421,
+    "wof:lastmodified":1589219003,
     "wof:name":"Ogden Hinckley Airport",
     "wof:parent_id":85829987,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/103/102530103.geojson
+++ b/data/102/530/103/102530103.geojson
@@ -25,7 +25,7 @@
         "KNGU"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -50,7 +50,7 @@
         "icao:code":"KNGU"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530103,
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":102530103,
-    "wof:lastmodified":1566609410,
+    "wof:lastmodified":1589219003,
     "wof:name":"Norfolk Naval Air Station",
     "wof:parent_id":85851637,
     "wof:placetype":"campus",
@@ -79,5 +79,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/137/102530137.geojson
+++ b/data/102/530/137/102530137.geojson
@@ -21,7 +21,7 @@
         "XNO",
         "KXNO"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -41,7 +41,7 @@
         "icao:code":"KXNO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530137,
@@ -50,7 +50,7 @@
         }
     ],
     "wof:id":102530137,
-    "wof:lastmodified":1566609420,
+    "wof:lastmodified":1589219003,
     "wof:name":"North Air Force Auxiliary Base",
     "wof:parent_id":85688683,
     "wof:placetype":"campus",
@@ -67,5 +67,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/159/102530159.geojson
+++ b/data/102/530/159/102530159.geojson
@@ -31,7 +31,7 @@
         "Paloma International Airport"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":316,
     "woe:hierarchy":{
@@ -54,7 +54,7 @@
         "wk:page":"Nogales International Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530159,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102530159,
-    "wof:lastmodified":1566609411,
+    "wof:lastmodified":1589219003,
     "wof:name":"Nogales International Airport",
     "wof:parent_id":85688719,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/417/102530417.geojson
+++ b/data/102/530/417/102530417.geojson
@@ -32,7 +32,7 @@
     "name:tgk_x_preferred":[
         "\u041f\u043e\u0439\u0433\u043e\u04b3\u0438 \u043e\u0431\u200c\u043d\u0448\u0441\u0442\u043d \u0434\u0430\u0440\u0451\u0447\u0430 \u0431\u0440\u0443\u043a\u0441"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":154,
     "woe:hierarchy":{
@@ -52,7 +52,7 @@
         "iata:code":"BKF"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530417,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102530417,
-    "wof:lastmodified":1566609421,
+    "wof:lastmodified":1589219003,
     "wof:name":"Lake Brooks Seaplane Base",
     "wof:parent_id":85688573,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/471/102530471.geojson
+++ b/data/102/530/471/102530471.geojson
@@ -21,7 +21,7 @@
         "RCX",
         "KRCX"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":30,
     "woe:hierarchy":{
@@ -42,7 +42,7 @@
         "icao:code":"KRCX"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530471,
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":102530471,
-    "wof:lastmodified":1566609412,
+    "wof:lastmodified":1589219003,
     "wof:name":"Rusk County Airport",
     "wof:parent_id":85688517,
     "wof:placetype":"campus",
@@ -68,5 +68,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/473/102530473.geojson
+++ b/data/102/530/473/102530473.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0440\u043e\u0431\u0438\u0440\u0442 \u04b6\u0438\u0439. \u043c\u0435\u043b\u0438\u0440"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":383,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KMJX"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530473,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102530473,
-    "wof:lastmodified":1566609422,
+    "wof:lastmodified":1589219003,
     "wof:name":"Robert J Miller Air Park",
     "wof:parent_id":85809889,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/595/102530595.geojson
+++ b/data/102/530/595/102530595.geojson
@@ -23,7 +23,7 @@
         "Roscommon County\u2013Blodgett Memorial Airport",
         "Roscommon County-Blodgett Memorial Airport"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":277,
     "woe:hierarchy":{
@@ -45,7 +45,7 @@
         "icao:code":"KHTL"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530595,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102530595,
-    "wof:lastmodified":1566609411,
+    "wof:lastmodified":1589219003,
     "wof:name":"Roscommon County Airport",
     "wof:parent_id":85688599,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/599/102530599.geojson
+++ b/data/102/530/599/102530599.geojson
@@ -21,7 +21,7 @@
         "RKR",
         "KRKR"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":272,
     "woe:hierarchy":{
@@ -44,7 +44,7 @@
         "icao:code":"KRKR"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530599,
@@ -55,7 +55,7 @@
         }
     ],
     "wof:id":102530599,
-    "wof:lastmodified":1566609419,
+    "wof:lastmodified":1589219003,
     "wof:name":"Robert S Kerr Airport",
     "wof:parent_id":101714401,
     "wof:placetype":"campus",
@@ -72,5 +72,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/530/643/102530643.geojson
+++ b/data/102/530/643/102530643.geojson
@@ -21,7 +21,7 @@
         "RSV",
         "KRSV"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -41,7 +41,7 @@
         "icao:code":"KRSV"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102530643,
@@ -50,7 +50,7 @@
         }
     ],
     "wof:id":102530643,
-    "wof:lastmodified":1566609412,
+    "wof:lastmodified":1589219003,
     "wof:name":"Robinson Municipal Airport",
     "wof:parent_id":85688697,
     "wof:placetype":"campus",
@@ -67,5 +67,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/031/102531031.geojson
+++ b/data/102/531/031/102531031.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u043c\u0438\u043e\u043c\u0438"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":534,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KMIO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531031,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102531031,
-    "wof:lastmodified":1566609432,
+    "wof:lastmodified":1589219003,
     "wof:name":"Miami Municipal Airport",
     "wof:parent_id":101714125,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/061/102531061.geojson
+++ b/data/102/531/061/102531061.geojson
@@ -30,7 +30,7 @@
     "name:und_x_variant":[
         "Millinocket Airport"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":214,
     "woe:hierarchy":{
@@ -55,7 +55,7 @@
         "wk:page":"Millinocket Municipal Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531061,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":102531061,
-    "wof:lastmodified":1566609442,
+    "wof:lastmodified":1589219003,
     "wof:name":"Millinocket Municipal Airport",
     "wof:parent_id":85949113,
     "wof:placetype":"campus",
@@ -83,5 +83,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/065/102531065.geojson
+++ b/data/102/531/065/102531065.geojson
@@ -29,7 +29,7 @@
         "Minot Air Force Base CDP"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "src:population":"geonames",
     "wd:wordcount":4330,
@@ -55,7 +55,7 @@
         "qs_pg:id":357121
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531065,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":102531065,
-    "wof:lastmodified":1566609432,
+    "wof:lastmodified":1589219003,
     "wof:name":"Minot Air Force Base",
     "wof:parent_id":85982739,
     "wof:placetype":"campus",
@@ -85,5 +85,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/121/102531121.geojson
+++ b/data/102/531/121/102531121.geojson
@@ -21,7 +21,7 @@
         "VTN",
         "KVTN"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "icao:code":"KVTN"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531121,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102531121,
-    "wof:lastmodified":1566609436,
+    "wof:lastmodified":1589219003,
     "wof:name":"Miller Field Airport",
     "wof:parent_id":85973581,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/127/102531127.geojson
+++ b/data/102/531/127/102531127.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043c\u0441\u043a\u0443\u043e\u0438\u0442 \u043c\u0438\u0442\u0440\u0443"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":353,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KHQZ"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531127,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102531127,
-    "wof:lastmodified":1566609435,
+    "wof:lastmodified":1589219003,
     "wof:name":"Mesquite Metro Airport",
     "wof:parent_id":85878899,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/163/102531163.geojson
+++ b/data/102/531/163/102531163.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043c\u0430\u043d\u0442\u0430\u049b\u0430\u200c\u0438\u0439 \u043c\u0438\u0434-\u043e\u0441\u0442\u0438\u0442"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":782,
     "woe:hierarchy":{
@@ -48,7 +48,7 @@
         "icao:code":"KPSB"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531163,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102531163,
-    "wof:lastmodified":1566609437,
+    "wof:lastmodified":1589219003,
     "wof:name":"Mid State Airport",
     "wof:parent_id":85688481,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/329/102531329.geojson
+++ b/data/102/531/329/102531329.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0447\u043d\u0434\u043b\u0440"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":685,
     "woe:hierarchy":{
@@ -52,7 +52,7 @@
         "icao:code":"KCHD"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531329,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":102531329,
-    "wof:lastmodified":1566609443,
+    "wof:lastmodified":1589219003,
     "wof:name":"Chandler Municipal Airport",
     "wof:parent_id":85876661,
     "wof:placetype":"campus",
@@ -81,5 +81,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/343/102531343.geojson
+++ b/data/102/531/343/102531343.geojson
@@ -33,7 +33,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0447\u043e\u0440\u043b\u0443\u0432\u0438\u043a\u0441"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":469,
     "woe:hierarchy":{
@@ -56,7 +56,7 @@
         "icao:code":"KCVX"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531343,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":102531343,
-    "wof:lastmodified":1566609445,
+    "wof:lastmodified":1589219003,
     "wof:name":"Charlevoix Municipal Airport",
     "wof:parent_id":85951817,
     "wof:placetype":"campus",
@@ -84,5 +84,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/379/102531379.geojson
+++ b/data/102/531/379/102531379.geojson
@@ -21,7 +21,7 @@
         "OLE",
         "KOLE"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":288,
     "woe:hierarchy":{
@@ -42,7 +42,7 @@
         "icao:code":"KOLE"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531379,
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":102531379,
-    "wof:lastmodified":1566609434,
+    "wof:lastmodified":1589219003,
     "wof:name":"Cattaraugus County-Olean Airport",
     "wof:parent_id":85688543,
     "wof:placetype":"campus",
@@ -68,5 +68,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/509/102531509.geojson
+++ b/data/102/531/509/102531509.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043a\u0440\u0438\u0441\u043f \u041a\u043e\u043d-\u043a\u0443\u0440\u0434\u043b"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":464,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KCKF"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531509,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102531509,
-    "wof:lastmodified":1566609438,
+    "wof:lastmodified":1589219003,
     "wof:name":"Crisp County-Cordele Airport",
     "wof:parent_id":85936593,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/593/102531593.geojson
+++ b/data/102/531/593/102531593.geojson
@@ -21,7 +21,7 @@
         "AJO",
         "KAJO"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":538,
     "woe:hierarchy":{
@@ -45,7 +45,7 @@
         "icao:code":"KAJO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531593,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102531593,
-    "wof:lastmodified":1566609428,
+    "wof:lastmodified":1589219003,
     "wof:name":"Corona Municipal Airport",
     "wof:parent_id":85876931,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/531/965/102531965.geojson
+++ b/data/102/531/965/102531965.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0438\u0441\u0442\u043e\u043d \u043e\u0442\u043a\u0438\u043d\u0441\u043d"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":473,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KPTS"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102531965,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102531965,
-    "wof:lastmodified":1566609428,
+    "wof:lastmodified":1589219003,
     "wof:name":"Atkinson Municipal Airport",
     "wof:parent_id":85946159,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/055/102532055.geojson
+++ b/data/102/532/055/102532055.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0432\u043f\u043e\u043a\u043e"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":311,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KPCZ"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532055,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102532055,
-    "wof:lastmodified":1566608599,
+    "wof:lastmodified":1589219002,
     "wof:name":"Waupaca Municipal Airport",
     "wof:parent_id":101733389,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/067/102532067.geojson
+++ b/data/102/532/067/102532067.geojson
@@ -21,7 +21,7 @@
         "UNO",
         "KUNO"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":350,
     "woe:hierarchy":{
@@ -42,7 +42,7 @@
         "icao:code":"KUNO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532067,
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":102532067,
-    "wof:lastmodified":1566608609,
+    "wof:lastmodified":1589219002,
     "wof:name":"West Plains Municipal Airport",
     "wof:parent_id":85688661,
     "wof:placetype":"campus",
@@ -68,5 +68,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/147/102532147.geojson
+++ b/data/102/532/147/102532147.geojson
@@ -21,7 +21,7 @@
         "RYV",
         "KRYV"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":34,
     "woe:hierarchy":{
@@ -44,7 +44,7 @@
         "icao:code":"KRYV"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532147,
@@ -55,7 +55,7 @@
         }
     ],
     "wof:id":102532147,
-    "wof:lastmodified":1566608611,
+    "wof:lastmodified":1589219002,
     "wof:name":"Watertown Municipal Airport",
     "wof:parent_id":101732305,
     "wof:placetype":"campus",
@@ -72,5 +72,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/161/102532161.geojson
+++ b/data/102/532/161/102532161.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0432\u043e\u0442\u0440\u0431\u0440\u0438-\u043e\u043a\u0441\u0444\u0443\u0440\u0434"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":938,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KOXC"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532161,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102532161,
-    "wof:lastmodified":1566608594,
+    "wof:lastmodified":1589219002,
     "wof:name":"Waterbury Oxford Airport",
     "wof:parent_id":85850263,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/245/102532245.geojson
+++ b/data/102/532/245/102532245.geojson
@@ -31,7 +31,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u043f\u0440\u0438\u043d\u0441\u0442\u043d"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":323,
     "woe:hierarchy":{
@@ -56,7 +56,7 @@
         "wk:page":"Princeton Municipal Airport (Minnesota)"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532245,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":102532245,
-    "wof:lastmodified":1534379472,
+    "wof:lastmodified":1589219002,
     "wof:name":"Princeton Municipal Airport",
     "wof:parent_id":85968823,
     "wof:placetype":"campus",
@@ -86,5 +86,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/295/102532295.geojson
+++ b/data/102/532/295/102532295.geojson
@@ -24,7 +24,7 @@
         "POE"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "iata:code":"POE"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532295,
@@ -52,7 +52,7 @@
         }
     ],
     "wof:id":102532295,
-    "wof:lastmodified":1566608599,
+    "wof:lastmodified":1589219002,
     "wof:name":"Polk Army Air Field",
     "wof:parent_id":85688735,
     "wof:placetype":"campus",
@@ -69,5 +69,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/313/102532313.geojson
+++ b/data/102/532/313/102532313.geojson
@@ -21,7 +21,7 @@
         "MPO",
         "KMPO"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":267,
     "woe:hierarchy":{
@@ -42,7 +42,7 @@
         "icao:code":"KMPO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532313,
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":102532313,
-    "wof:lastmodified":1566608603,
+    "wof:lastmodified":1589219002,
     "wof:name":"Pocono Mountains Municipal Airport",
     "wof:parent_id":85688481,
     "wof:placetype":"campus",
@@ -68,5 +68,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/409/102532409.geojson
+++ b/data/102/532/409/102532409.geojson
@@ -30,7 +30,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u043f\u043b\u0442\u0443\u0438\u043b"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":269,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KPVB"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532409,
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":102532409,
-    "wof:lastmodified":1566608599,
+    "wof:lastmodified":1589219002,
     "wof:name":"Platteville Municipal Airport",
     "wof:parent_id":85688517,
     "wof:placetype":"campus",
@@ -77,5 +77,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/431/102532431.geojson
+++ b/data/102/532/431/102532431.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043f\u0443\u0442\u0441\u200c\u0442\u043e\u0432\u043d \u043b\u0438\u043c\u0440\u043a"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":384,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KPTW"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532431,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102532431,
-    "wof:lastmodified":1566608599,
+    "wof:lastmodified":1589219002,
     "wof:name":"Pottstown Limerick Airport",
     "wof:parent_id":85830691,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/433/102532433.geojson
+++ b/data/102/532/433/102532433.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043f\u043b\u0441\u0440\u0443\u0438\u043b"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":315,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KPVF"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532433,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102532433,
-    "wof:lastmodified":1566608608,
+    "wof:lastmodified":1589219002,
     "wof:name":"Placerville Airport",
     "wof:parent_id":85886903,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/532/625/102532625.geojson
+++ b/data/102/532/625/102532625.geojson
@@ -34,7 +34,7 @@
         "Brainard Airport"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":270,
     "woe:hierarchy":{
@@ -61,7 +61,7 @@
         "wk:page":"Hartford\u2013Brainard Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102532625,
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":102532625,
-    "wof:lastmodified":1566608606,
+    "wof:lastmodified":1589219002,
     "wof:name":"Hartford-Brainard Airport",
     "wof:parent_id":85878029,
     "wof:placetype":"campus",
@@ -90,5 +90,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/151/102533151.geojson
+++ b/data/102/533/151/102533151.geojson
@@ -21,7 +21,7 @@
         "MQW",
         "KMQW"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":258,
     "woe:hierarchy":{
@@ -42,7 +42,7 @@
         "icao:code":"KMQW"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533151,
@@ -51,7 +51,7 @@
         }
     ],
     "wof:id":102533151,
-    "wof:lastmodified":1566608571,
+    "wof:lastmodified":1589219001,
     "wof:name":"Telfair Wheeler Airport",
     "wof:parent_id":85688535,
     "wof:placetype":"campus",
@@ -68,5 +68,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/313/102533313.geojson
+++ b/data/102/533/313/102533313.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u0442\u04b3\u043e\u0447\u043e\u043f\u0438"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":260,
     "woe:hierarchy":{
@@ -51,7 +51,7 @@
         "icao:code":"KTSP"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533313,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102533313,
-    "wof:lastmodified":1566608577,
+    "wof:lastmodified":1589219002,
     "wof:name":"Tehachapi Municipal Airport",
     "wof:parent_id":85851383,
     "wof:placetype":"campus",
@@ -80,5 +80,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/369/102533369.geojson
+++ b/data/102/533/369/102533369.geojson
@@ -21,7 +21,7 @@
         "OPL",
         "KOPL"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "icao:code":"KOPL"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533369,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102533369,
-    "wof:lastmodified":1566608579,
+    "wof:lastmodified":1589219002,
     "wof:name":"St Landry Parish Ahart Field Airport",
     "wof:parent_id":85948431,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/595/102533595.geojson
+++ b/data/102/533/595/102533595.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u043e\u0432\u0442\u043e\u0432\u043e"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":168,
     "woe:hierarchy":{
@@ -50,7 +50,7 @@
         "icao:code":"KOWI"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533595,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102533595,
-    "wof:lastmodified":1566608570,
+    "wof:lastmodified":1589219001,
     "wof:name":"Ottawa Municipal Airport",
     "wof:parent_id":85945713,
     "wof:placetype":"campus",
@@ -78,5 +78,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/641/102533641.geojson
+++ b/data/102/533/641/102533641.geojson
@@ -24,7 +24,7 @@
         "OZA"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "iata:code":"OZA"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533641,
@@ -52,7 +52,7 @@
         }
     ],
     "wof:id":102533641,
-    "wof:lastmodified":1566608581,
+    "wof:lastmodified":1589219002,
     "wof:name":"Ozona Municipal Airport",
     "wof:parent_id":85688753,
     "wof:placetype":"campus",
@@ -69,5 +69,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/665/102533665.geojson
+++ b/data/102/533/665/102533665.geojson
@@ -27,7 +27,7 @@
         "Palwaukee Municipal Airport"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -52,7 +52,7 @@
         "wk:page":"Chicago Executive Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533665,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":102533665,
-    "wof:lastmodified":1566608583,
+    "wof:lastmodified":1589219002,
     "wof:name":"Pal Waukee Airport",
     "wof:parent_id":85891073,
     "wof:placetype":"campus",
@@ -81,5 +81,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/669/102533669.geojson
+++ b/data/102/533/669/102533669.geojson
@@ -34,7 +34,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043e\u0432\u043a\u0441\u043d\u043e\u0440\u0434"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":1070,
     "woe:hierarchy":{
@@ -61,7 +61,7 @@
         "wk:page":"Oxnard Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533669,
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":102533669,
-    "wof:lastmodified":1566608573,
+    "wof:lastmodified":1589219001,
     "wof:name":"Oxnard Airport",
     "wof:parent_id":85879657,
     "wof:placetype":"campus",
@@ -90,5 +90,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/863/102533863.geojson
+++ b/data/102/533/863/102533863.geojson
@@ -24,7 +24,7 @@
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0634\u0647\u0631\u06cc \u0645\u0627\u0631\u0641\u0627"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":424,
     "woe:hierarchy":{
@@ -45,7 +45,7 @@
         "icao:code":"KMRF"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533863,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102533863,
-    "wof:lastmodified":1566608584,
+    "wof:lastmodified":1589219002,
     "wof:name":"Marfa Municipal Airport",
     "wof:parent_id":85688753,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/873/102533873.geojson
+++ b/data/102/533/873/102533873.geojson
@@ -21,7 +21,7 @@
         "MKT",
         "KMKT"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "icao:code":"KMKT"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533873,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102533873,
-    "wof:lastmodified":1566608571,
+    "wof:lastmodified":1589219001,
     "wof:name":"Mankato Municipal Airport",
     "wof:parent_id":85953345,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/883/102533883.geojson
+++ b/data/102/533/883/102533883.geojson
@@ -24,7 +24,7 @@
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0634\u0647\u0631\u06cc \u0645\u0627\u0646\u06cc\u0644\u0627"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":255,
     "woe:hierarchy":{
@@ -47,7 +47,7 @@
         "icao:code":"KMXA"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533883,
@@ -58,7 +58,7 @@
         }
     ],
     "wof:id":102533883,
-    "wof:lastmodified":1566608580,
+    "wof:lastmodified":1589219002,
     "wof:name":"Manila Municipal Airport",
     "wof:parent_id":85920879,
     "wof:placetype":"campus",
@@ -75,5 +75,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/941/102533941.geojson
+++ b/data/102/533/941/102533941.geojson
@@ -24,7 +24,7 @@
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0634\u0647\u0631\u0633\u062a\u0627\u0646 \u0645\u0646\u06cc\u062a\u0648\u0627\u06a9"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":297,
     "woe:hierarchy":{
@@ -48,7 +48,7 @@
         "icao:code":"KMTW"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533941,
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":102533941,
-    "wof:lastmodified":1566608576,
+    "wof:lastmodified":1589219002,
     "wof:name":"Manitowoc County Airport",
     "wof:parent_id":85832123,
     "wof:placetype":"campus",
@@ -77,5 +77,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/533/977/102533977.geojson
+++ b/data/102/533/977/102533977.geojson
@@ -21,7 +21,7 @@
         "HDO",
         "KHDO"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "icao:code":"KHDO"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102533977,
@@ -54,7 +54,7 @@
         }
     ],
     "wof:id":102533977,
-    "wof:lastmodified":1566608575,
+    "wof:lastmodified":1589219002,
     "wof:name":"Hondo Municipal Airport",
     "wof:parent_id":101725519,
     "wof:placetype":"campus",
@@ -71,5 +71,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/534/101/102534101.geojson
+++ b/data/102/534/101/102534101.geojson
@@ -21,7 +21,7 @@
         "UMP",
         "KUMP"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -44,7 +44,7 @@
         "icao:code":"KUMP"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102534101,
@@ -56,7 +56,7 @@
         }
     ],
     "wof:id":102534101,
-    "wof:lastmodified":1566608591,
+    "wof:lastmodified":1589219002,
     "wof:name":"Indianapolis Metro Airport",
     "wof:parent_id":85891119,
     "wof:placetype":"campus",
@@ -73,5 +73,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }

--- a/data/102/534/321/102534321.geojson
+++ b/data/102/534/321/102534321.geojson
@@ -27,7 +27,7 @@
     "name:tgk_x_preferred":[
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0438\u0441\u0442\u043e\u043d \u043b\u0438\u043d \u04b3\u043b\u043c\u0437 \u0441\u0443\u0438\u0440"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "wd:wordcount":345,
     "woe:hierarchy":{
@@ -48,7 +48,7 @@
         "icao:code":"KDEQ"
     },
     "wof:country":"US",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102534321,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":102534321,
-    "wof:lastmodified":1566608592,
+    "wof:lastmodified":1589219002,
     "wof:name":"J Lynn Helms Sevier County Airport",
     "wof:parent_id":85688549,
     "wof:placetype":"campus",
@@ -74,5 +74,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst/whosonfirst-sources/issues/112.

Swaps any "missing" values in `src:geom` properties to "unknown". I also checked values in `src:geom_alt` and `wof:geom_alt` properties, but there were no cases.

No PIP required, can merge once approved.