### PR TITLE
Update population for Liverpool, US

### DIFF
--- a/data/101/717/443/101717443.geojson
+++ b/data/101/717/443/101717443.geojson
@@ -95,16 +95,17 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
+    "src:population_date":"2010",
     "wd:latitude":53.416667,
     "wd:longitude":-3.0,
     "wd:population":466415,
     "wd:wordcount":17494,
     "wof:belongsto":[
-        85688481,
         102191575,
-        404485853,
         85633793,
-        102080963
+        102080963,
+        404485853,
+        85688481
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -134,12 +135,12 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582338225,
+    "wof:lastmodified":1593217390,
     "wof:name":"Liverpool",
     "wof:parent_id":404485853,
     "wof:placetype":"locality",
-    "wof:population":466415,
-    "wof:population_rank":10,
+    "wof:population":955,
+    "wof:population_rank":2,
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],
     "wof:supersedes":[],


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1860

Updates population data for the Liverpool, PA record.