### PR TITLE
fix lbl:bbox for 1713109987

### DIFF
--- a/data/171/310/998/7/1713109987.geojson
+++ b/data/171/310/998/7/1713109987.geojson
@@ -26,7 +26,7 @@
     "gn:population":30892,
     "gn:timezone":"America/New_York",
     "iso:country":"US",
-    "lbl:bbox":"-75.3876940.044,-75.38769,40.044",
+    "lbl:bbox":"-75.38769,40.044,-75.38769,40.044",
     "lbl:max_zoom":15.0,
     "lbl:min_zoom":11.5,
     "mz:hierarchy_label":1,
@@ -91,7 +91,7 @@
         }
     ],
     "wof:id":1713109987,
-    "wof:lastmodified":1588371461,
+    "wof:lastmodified":1595501975,
     "wof:name":"Wayne",
     "wof:parent_id":404485519,
     "wof:placetype":"locality",


### PR DESCRIPTION
As reported in https://github.com/pelias/placeholder/issues/183, 1713109987 has an invalid `lbl:bbox` param.