### PR TITLE
Flag duplicate localities

### DIFF
--- a/data/120/923/074/7/1209230747.geojson
+++ b/data/120/923/074/7/1209230747.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-08-21",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -29,7 +30,7 @@
     "lbl:max_zoom":15.0,
     "lbl:min_zoom":11.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
         "\u0644\u064a\u062a\u0634\u0641\u064a\u0644\u062f \u0628\u0627\u0631\u0643"
@@ -144,14 +145,16 @@
         }
     ],
     "wof:id":1209230747,
-    "wof:lastmodified":1566622398,
+    "wof:lastmodified":1598051810,
     "wof:name":"Litchfield Park",
     "wof:parent_id":85633793,
     "wof:placetype":"locality",
     "wof:population":5533,
     "wof:population_rank":5,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        85917495
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/124/308/370/1/1243083701.geojson
+++ b/data/124/308/370/1/1243083701.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-08-21",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -30,7 +31,7 @@
     "lbl:max_zoom":14.0,
     "lbl:min_zoom":9.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":8.0,
     "name:afr_x_preferred":[
         "Gary"
@@ -230,11 +231,11 @@
     "src:geom":"geonames",
     "src:population":"geonames",
     "wof:belongsto":[
-        85688709,
         102191575,
-        404501857,
         85633793,
-        102087149
+        102087149,
+        404501857,
+        85688709
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -254,14 +255,16 @@
         }
     ],
     "wof:id":1243083701,
-    "wof:lastmodified":1566639791,
+    "wof:lastmodified":1598051815,
     "wof:name":"Gary",
     "wof:parent_id":404501857,
     "wof:placetype":"locality",
     "wof:population":77156,
     "wof:population_rank":8,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        85941813
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/859/174/95/85917495.geojson
+++ b/data/859/174/95/85917495.geojson
@@ -219,8 +219,8 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688719,
-        102087421
+        102087421,
+        85688719
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -233,6 +233,7 @@
         "wk:page":"Litchfield Park, Arizona"
     },
     "wof:concordances_alt":{
+        "gn:id":5302053,
         "qs_pg:id":324070
     },
     "wof:country":"US",
@@ -253,7 +254,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582335771,
+    "wof:lastmodified":1598051806,
     "wof:name":"Litchfield Park",
     "wof:parent_id":102087421,
     "wof:placetype":"locality",
@@ -262,7 +263,8 @@
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],
     "wof:supersedes":[
-        1125296659
+        1125296659,
+        1209230747
     ],
     "wof:tags":[]
 },

--- a/data/859/418/13/85941813.geojson
+++ b/data/859/418/13/85941813.geojson
@@ -388,6 +388,7 @@
         "wk:page":"Gary, Indiana"
     },
     "wof:concordances_alt":{
+        "gn:id":4920607,
         "qs_pg:id":456181
     },
     "wof:country":"US",
@@ -409,7 +410,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1587163141,
+    "wof:lastmodified":1598051820,
     "wof:megacity":0,
     "wof:name":"Gary",
     "wof:parent_id":404501857,
@@ -420,7 +421,8 @@
     "wof:scale":7,
     "wof:superseded_by":[],
     "wof:supersedes":[
-        1125321055
+        1125321055,
+        1243083701
     ],
     "wof:tags":[]
 },


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1875

This PR flags two duplicate localities in the US, deprecating them and superseding them into the "current" record for the locality. I stored alt concordances in these records, rather than conflating top-level properties.

No PIP work needed, can merge once approved.