### PR TITLE
Deprecate bunk locality

### DIFF
--- a/data/112/580/821/1/1125808211.geojson
+++ b/data/112/580/821/1/1125808211.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2020-09-11",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -19,7 +20,7 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "qs_pg:aaroncc":"US",
@@ -45,11 +46,11 @@
     "woe:name_adm1":"Pennsylvania",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85688481,
         102191575,
-        404485401,
         85633793,
-        102080879
+        102080879,
+        404485401,
+        85688481
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1125808211,
-    "wof:lastmodified":1566635962,
+    "wof:lastmodified":1599866844,
     "wof:name":"Finton",
     "wof:parent_id":404485401,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1835.

This PR simply deprecates a locality record for "Finton, PA", which doesn't actually exist. The locality likely represents "Flinton, PA", which WOF has a record for ([here](https://spelunker.whosonfirst.org/id/1125808325/)).

I did not supersede or bring over any properties.. the Flinton record is fine as-is and should not gain new properties from the bunk Finton record. No PIP work, can merge once approved.