### PR TITLE
Add population info to Chapel Hill locality record

### DIFF
--- a/data/859/805/63/85980563.geojson
+++ b/data/859/805/63/85980563.geojson
@@ -198,12 +198,14 @@
         "quattroshapes_pg"
     ],
     "src:lbl_centroid":"mapshaper",
+    "src:population":"wd",
+    "src:population_date":2010,
     "wd:wordcount":164,
     "wof:belongsto":[
         102191575,
         85633793,
-        85688773,
-        102087647
+        102087647,
+        85688773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -235,10 +237,12 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582335764,
+    "wof:lastmodified":1601583517,
     "wof:name":"Chapel Hill",
     "wof:parent_id":102087647,
     "wof:placetype":"locality",
+    "wof:population":57233,
+    "wof:population_rank":8,
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],
     "wof:supersedes":[],


### PR DESCRIPTION
This PR adds population, population_rank, and population source information to the Chapel Hill, NC record. No PIP work needed, can merge once approved.