### PR TITLE
Update preferred name lists

### DIFF
--- a/data/110/893/614/9/1108936149.geojson
+++ b/data/110/893/614/9/1108936149.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-97.5250765185,35.4763417286,-97.5250765185,35.4763417286",
+    "geom:bbox":"-97.525077,35.476342,-97.525077,35.476342",
     "geom:latitude":35.476342,
     "geom:longitude":-97.525077,
     "iso:country":"US",
@@ -24,19 +24,21 @@
     "mz:min_zoom":16.0,
     "mz:tier_metro":15,
     "name:eng_x_preferred":[
+        "SOSA"
+    ],
+    "name:eng_x_variant":[
+        "SoSA",
         "Cottage District",
         "South of St. Anthony"
     ],
-    "name:eng_x_variant":[
-        "SoSA"
-    ],
+    "src:geom":"unknown",
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
-        85688585,
         102191575,
         85633793,
+        102082577,
         101714461,
-        102082577
+        85688585
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -44,7 +46,7 @@
     },
     "wof:country":"US",
     "wof:created":1491358834,
-    "wof:geomhash":"97f9b446420db0fe80b7e79c87d2be24",
+    "wof:geomhash":"147d55e7031e6a3bf0accc84e6cd3551",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -56,7 +58,7 @@
         }
     ],
     "wof:id":1108936149,
-    "wof:lastmodified":1566624010,
+    "wof:lastmodified":1602620564,
     "wof:name":"SOSA",
     "wof:parent_id":101714461,
     "wof:placetype":"neighbourhood",
@@ -66,10 +68,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -97.52507651850893,
-    35.47634172859343,
-    -97.52507651850893,
-    35.47634172859343
+    -97.525077,
+    35.476342,
+    -97.525077,
+    35.476342
 ],
-  "geometry": {"coordinates":[-97.52507651850893,35.47634172859343],"type":"Point"}
+  "geometry": {"coordinates":[-97.525077,35.476342],"type":"Point"}
 }

--- a/data/110/893/677/1/1108936771.geojson
+++ b/data/110/893/677/1/1108936771.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-76.4636015002,37.057837185,-76.4636015002,37.057837185",
+    "geom:bbox":"-76.463602,37.057837,-76.463602,37.057837",
     "geom:latitude":37.057837,
     "geom:longitude":-76.463602,
     "iso:country":"US",
@@ -24,22 +24,23 @@
     "mz:min_zoom":13.0,
     "mz:tier_metro":15,
     "name:eng_x_preferred":[
-        "Gum Grove",
-        "Harpersville"
+        "Morrison"
     ],
     "name:eng_x_variant":[
-        "Morrison"
+        "Gum Grove",
+        "Harpersville"
     ],
     "name:fra_x_preferred":[
         "Morrison"
     ],
+    "src:geom":"unknown",
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
-        85688747,
         102191575,
         85633793,
+        102085961,
         101729041,
-        102085961
+        85688747
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -47,7 +48,7 @@
     },
     "wof:country":"US",
     "wof:created":1491359222,
-    "wof:geomhash":"60494585d198b225926dd6c2212eceed",
+    "wof:geomhash":"a6a2fc7a47872ac8984a3bb685fffd4a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -59,7 +60,7 @@
         }
     ],
     "wof:id":1108936771,
-    "wof:lastmodified":1566624019,
+    "wof:lastmodified":1602620569,
     "wof:name":"Morrison",
     "wof:parent_id":101729041,
     "wof:placetype":"neighbourhood",
@@ -69,10 +70,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -76.46360150019122,
-    37.05783718502074,
-    -76.46360150019122,
-    37.05783718502074
+    -76.463602,
+    37.057837,
+    -76.463602,
+    37.057837
 ],
-  "geometry": {"coordinates":[-76.46360150019122,37.05783718502074],"type":"Point"}
+  "geometry": {"coordinates":[-76.46360199999999,37.057837],"type":"Point"}
 }

--- a/data/110/893/678/5/1108936785.geojson
+++ b/data/110/893/678/5/1108936785.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-76.2750313827,36.86310713,-76.2750313827,36.86310713",
+    "geom:bbox":"-76.275031,36.863107,-76.275031,36.863107",
     "geom:latitude":36.863107,
     "geom:longitude":-76.275031,
     "gn:country":null,
@@ -25,11 +25,11 @@
     "mz:min_zoom":15.0,
     "mz:tier_metro":15,
     "name:eng_x_preferred":[
-        "Olde Huntersville",
-        "Hunters Village"
+        "Huntersville"
     ],
     "name:eng_x_variant":[
-        "Huntersville"
+        "Olde Huntersville",
+        "Hunters Village"
     ],
     "qs_pg:aaroncc":"US",
     "qs_pg:gn_country":null,
@@ -48,13 +48,14 @@
     "qs_pg:qs_pg_placetype_gp":"Suburb",
     "qs_pg:woe_adm0":23424977,
     "qs_pg:woe_id":2425751,
+    "src:geom":"unknown",
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
-        85688747,
         102191575,
         85633793,
+        102085935,
         101728769,
-        102085935
+        85688747
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -64,7 +65,7 @@
     },
     "wof:country":"US",
     "wof:created":1491359229,
-    "wof:geomhash":"a09845884d27e21879c4b40300e45759",
+    "wof:geomhash":"9044e422c81525aab044646dbf394e77",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108936785,
-    "wof:lastmodified":1566624014,
+    "wof:lastmodified":1602620590,
     "wof:name":"Huntersville",
     "wof:parent_id":101728769,
     "wof:placetype":"neighbourhood",
@@ -88,10 +89,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -76.27503138272886,
-    36.86310713002838,
-    -76.27503138272886,
-    36.86310713002838
+    -76.275031,
+    36.863107,
+    -76.275031,
+    36.863107
 ],
-  "geometry": {"coordinates":[-76.27503138272886,36.86310713002838],"type":"Point"}
+  "geometry": {"coordinates":[-76.275031,36.863107],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#1898.

No PIP work required. This PR updates the `name:eng_x_*` properties for three records in the US admin repo.