### PR TITLE
Update Sienna locality name

### DIFF
--- a/data/101/727/453/101727453.geojson
+++ b/data/101/727/453/101727453.geojson
@@ -19,65 +19,116 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
-    "name:azb_x_preferred":[
+    "name:azb_x_historical":[
         "\u0633\u06cc\u06cc\u0646\u0627 \u067e\u0644\u0646\u062a\u06cc\u0634\u0646"
     ],
+    "name:cat_x_historical":[
+        "Sienna Plantation"
+    ],
     "name:cat_x_preferred":[
+        "Sienna"
+    ],
+    "name:ceb_x_historical":[
         "Sienna Plantation"
     ],
     "name:ceb_x_preferred":[
+        "Sienna"
+    ],
+    "name:deu_x_historical":[
         "Sienna Plantation"
     ],
     "name:deu_x_preferred":[
+        "Sienna"
+    ],
+    "name:eng_x_historical":[
         "Sienna Plantation"
     ],
     "name:eng_x_preferred":[
+        "Sienna"
+    ],
+    "name:eus_x_historical":[
         "Sienna Plantation"
     ],
     "name:eus_x_preferred":[
-        "Sienna Plantation"
+        "Sienna"
     ],
-    "name:fas_x_preferred":[
+    "name:fas_x_historical":[
         "\u0633\u06cc\u06cc\u0646\u0627 \u067e\u0644\u0646\u062a\u06cc\u0634\u0646"
     ],
+    "name:fra_x_historical":[
+        "Sienna Plantation"
+    ],
     "name:fra_x_preferred":[
+        "Sienna"
+    ],
+    "name:hat_x_historical":[
         "Sienna Plantation"
     ],
     "name:hat_x_preferred":[
+        "Sienna"
+    ],
+    "name:hrv_x_historical":[
         "Sienna Plantation"
     ],
     "name:hrv_x_preferred":[
+        "Sienna"
+    ],
+    "name:ita_x_historical":[
         "Sienna Plantation"
     ],
     "name:ita_x_preferred":[
-        "Sienna Plantation"
+        "Sienna"
     ],
-    "name:jpn_x_preferred":[
+    "name:jpn_x_historical":[
         "\u30b7\u30a8\u30ca\u30fb\u30d7\u30e9\u30f3\u30c6\u30fc\u30b7\u30e7\u30f3"
     ],
+    "name:nan_x_historical":[
+        "Sienna Plantation"
+    ],
     "name:nan_x_preferred":[
+        "Sienna"
+    ],
+    "name:nld_x_historical":[
         "Sienna Plantation"
     ],
     "name:nld_x_preferred":[
+        "Sienna"
+    ],
+    "name:pol_x_historical":[
         "Sienna Plantation"
     ],
     "name:pol_x_preferred":[
+        "Sienna"
+    ],
+    "name:por_x_historical":[
         "Sienna Plantation"
     ],
     "name:por_x_preferred":[
+        "Sienna"
+    ],
+    "name:spa_x_historical":[
         "Sienna Plantation"
     ],
     "name:spa_x_preferred":[
-        "Sienna Plantation"
+        "Sienna"
     ],
-    "name:srp_x_preferred":[
+    "name:srp_x_historical":[
         "\u0421\u0438\u0458\u0435\u043d\u0430 \u041f\u043b\u0430\u043d\u0442\u0435\u0458\u0448\u043e\u043d"
     ],
+    "name:srp_x_preferred":[
+        "\u0421\u0438\u0458\u0435\u043d\u0430"
+    ],
+    "name:vie_x_historical":[
+        "Sienna Plantation"
+    ],
     "name:vie_x_preferred":[
+        "Sienna"
+    ],
+    "name:vol_x_historical":[
         "Sienna Plantation"
     ],
     "name:vol_x_preferred":[
-        "Sienna Plantation"
+        "Sienna"
     ],
     "qs:a0":"United States",
     "qs:a1":"*Texas",
@@ -102,8 +153,8 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688753,
-        102087339
+        102087339,
+        85688753
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -113,7 +164,7 @@
         "gp:id":23418096,
         "qs_pg:id":688583,
         "wd:id":"Q981608",
-        "wk:page":"Sienna Plantation, Texas"
+        "wk:page":"Sienna, Texas"
     },
     "wof:country":"US",
     "wof:geom_alt":[
@@ -133,8 +184,8 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582338306,
-    "wof:name":"Sienna Plantation",
+    "wof:lastmodified":1616784094,
+    "wof:name":"Sienna",
     "wof:parent_id":102087339,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",


### PR DESCRIPTION
Updates the names for the locality of Sienna, Texas. This place was formerly known as "Sienna Plantation", so I've moved the existing names to historical names and updated preferred names. I've also updated the Wikipedia concordance.

No PIP work needed.

https://en.wikipedia.org/wiki/Sienna,_Texas