### PR TITLE
Update locality name

### DIFF
--- a/data/131/022/087/1/1310220871.geojson
+++ b/data/131/022/087/1/1310220871.geojson
@@ -33,18 +33,22 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "name:eng_x_preferred":[
-        "Lalimere"
+        "La Lumiere"
+    ],
+    "name:eng_x_variant":[
+        "Lalimere",
+        "Lalumiere"
     ],
     "name:und_x_variant":[
         "Wilhelm"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
-        85688709,
         102191575,
-        404501795,
         85633793,
-        102086409
+        102086409,
+        404501795,
+        85688709
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,8 +67,8 @@
         }
     ],
     "wof:id":1310220871,
-    "wof:lastmodified":1613721163,
-    "wof:name":"Lalimere",
+    "wof:lastmodified":1616791681,
+    "wof:name":"La Lumiere",
     "wof:parent_id":404501795,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",


### PR DESCRIPTION
This PR updates the names for the locality record for La Lumiere, MI. This place name matches the school in this area: https://www.lalumiere.org/

Roughly this area: 41.704051, -86.710547

This is a Point, so no need for PIP work. Can merge once approved.