### PR TITLE
Update washington dc region label

### DIFF
--- a/data/856/887/41/85688741.geojson
+++ b/data/856/887/41/85688741.geojson
@@ -15,13 +15,16 @@
     "iso:country":"US",
     "iso:subdivision":"US-DC",
     "label:eng_x_preferred_longname":[
-        "Washington, D.C."
+        "D.C."
     ],
     "label:eng_x_preferred_placetype":[
         "federal district"
     ],
     "label:eng_x_preferred_shortcode":[
         "DC"
+    ],
+    "label:eng_x_variant_longname":[
+        "Washington, D.C."
     ],
     "lbl:latitude":38.912097,
     "lbl:longitude":-77.014683,
@@ -940,7 +943,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1607124855,
+    "wof:lastmodified":1619218288,
     "wof:name":"District of Columbia",
     "wof:parent_id":85633793,
     "wof:placetype":"region",


### PR DESCRIPTION
This PR updates the `label` properties on the Washington DC region record. DC is an odd case; WOF has both a locality and a region record for Washington, which is referred to as simply "Washington, D.C.". This update allows services and WOF users to pull in these label properties for a "Washington, D.C." label string ("Washington" coming from the locality, "D.C." coming from the region).

No PIP work needed, can merge as-is.