### PR TITLE
(1951) Fix population for Detroit village in Illinois

### DIFF
--- a/data/859/396/49/85939649.geojson
+++ b/data/859/396/49/85939649.geojson
@@ -160,12 +160,11 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1613615404,
+    "wof:lastmodified":1627381271,
     "wof:name":"Detroit",
     "wof:parent_id":404496653,
     "wof:placetype":"locality",
-    "wof:population":680250,
-    "wof:population_rank":11,
+    "wof:population":81,
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],
     "wof:supersedes":[],


### PR DESCRIPTION
Issue link: https://github.com/whosonfirst-data/whosonfirst-data/issues/1951

Existing population figure was probably taken from Detroit MI. This is a problem for me when I list US cities in descending population order, and I get Detroit MI and Detroit IL one after the other.

The patch fixes the `wof:population` property, which is what I use.

Data sourced from US Census Bureau (2019):
https://www2.census.gov/programs-surveys/popest/tables/2010-2019/cities/totals/SUB-IP-EST2019-ANNRES-17.xlsx