### PR TITLE
Update Detroit locality

### DIFF
--- a/data/859/396/49/85939649.geojson
+++ b/data/859/396/49/85939649.geojson
@@ -160,12 +160,11 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1613615404,
+    "wof:lastmodified":1627381271,
     "wof:name":"Detroit",
     "wof:parent_id":404496653,
     "wof:placetype":"locality",
-    "wof:population":680250,
-    "wof:population_rank":11,
+    "wof:population":81,
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/859/396/49/85939649.geojson
+++ b/data/859/396/49/85939649.geojson
@@ -102,7 +102,7 @@
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"wk",
+    "src:population":"uscensus",
     "uscensus:aland":649302,
     "uscensus:awater":0,
     "uscensus:classfp":"C1",
@@ -119,10 +119,6 @@
     "uscensus:placefp":"19681",
     "uscensus:placens":"02398717",
     "uscensus:statefp":"17",
-    "wd:latitude":42.331667,
-    "wd:longitude":-83.0475,
-    "wd:population":680250,
-    "wd:wordcount":19115,
     "wof:belongsto":[
         102191575,
         85633793,
@@ -137,8 +133,7 @@
         "gn:id":4237004,
         "gp:id":2391578,
         "qs_pg:id":317258,
-        "uscensus:geoid":1719681,
-        "wd:id":"Q648770"
+        "uscensus:geoid":1719681
     },
     "wof:country":"US",
     "wof:geom_alt":[
@@ -160,11 +155,12 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1627381271,
+    "wof:lastmodified":1627401116,
     "wof:name":"Detroit",
     "wof:parent_id":404496653,
     "wof:placetype":"locality",
     "wof:population":81,
+    "wof:population_rank":1,
     "wof:repo":"whosonfirst-data-admin-us",
     "wof:superseded_by":[],
     "wof:supersedes":[],


### PR DESCRIPTION
Replaces #99.

This PR updates a "Detroit" locality record to:

- Remove the Wikidata concordance
- Update the `wof:population` and `wof:population_rank` values
- Remove top-level `wd:` properties
- Update the `src:population` value

No PIP work since this PR only includes property updates.