### PR TITLE
Rename locality 'Ohio' in the state of Ohio to 'Ohio Township'

### DIFF
--- a/data/172/943/888/3/1729438883.geojson
+++ b/data/172/943/888/3/1729438883.geojson
@@ -18,6 +18,9 @@
     "mz:is_current":1,
     "mz:min_zoom":30.0,
     "name:eng_x_preferred":[
+        "Ohio Township"
+    ],
+    "name:eng_x_variant":[
         "Ohio"
     ],
     "src:geom":"whosonfirst",

--- a/data/172/943/888/3/1729438883.geojson
+++ b/data/172/943/888/3/1729438883.geojson
@@ -44,8 +44,8 @@
         }
     ],
     "wof:id":1729438883,
-    "wof:lastmodified":1613765631,
-    "wof:name":"Ohio",
+    "wof:lastmodified":1629997636,
+    "wof:name":"Ohio Township",
     "wof:parent_id":404526723,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",


### PR DESCRIPTION
A report came in of a locality record in Ohio that is also called Ohio causing trouble for us with the Pelias Geocoder.

I understand the standard pattern in WOF seems to be to have a locality with a "short name", and then the parent localadmin will have a longer name, in this case 'Ohio Township'.

However, because of the possibility of conflicting with the name of the state, would it make sense to have _both_ the locality and localadmin named 'Ohio Township' in this case?

Updating `data/172/943/888/3/1729438883.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)