### PR TITLE
Rename another "Ohio" to Ohio Township (Gallia County)

### DIFF
--- a/data/172/947/454/1/1729474541.geojson
+++ b/data/172/947/454/1/1729474541.geojson
@@ -51,7 +51,7 @@
     ],
     "wof:id":1729474541,
     "wof:lastmodified":1632781703,
-    "wof:name":"Ohio",
+    "wof:name":"Ohio Township",
     "wof:parent_id":404524597,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",

--- a/data/172/947/454/1/1729474541.geojson
+++ b/data/172/947/454/1/1729474541.geojson
@@ -18,6 +18,9 @@
     "mz:is_current":1,
     "mz:min_zoom":30.0,
     "name:eng_x_preferred":[
+        "Ohio Township"
+    ],
+    "name:eng_x_variant":[
         "Ohio"
     ],
     "src:geom":"whosonfirst",
@@ -47,7 +50,7 @@
         }
     ],
     "wof:id":1729474541,
-    "wof:lastmodified":1613764846,
+    "wof:lastmodified":1632781703,
     "wof:name":"Ohio",
     "wof:parent_id":404524597,
     "wof:placetype":"locality",


### PR DESCRIPTION
Following https://github.com/whosonfirst-data/whosonfirst-data-admin-us/pull/102, it looks like there is _another_ Ohio Township in the state of Ohio. This one looks to be [the one](https://en.wikipedia.org/wiki/Ohio_Township,_Gallia_County,_Ohio) in [Gallia County](https://en.wikipedia.org/wiki/Gallia_County,_Ohio).

Updating `data/172/947/454/1/1729474541.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)