### PR TITLE
Add "Township" to name for "Ohio" locality in Clermont County, Ohio

### DIFF
--- a/data/172/944/349/1/1729443491.geojson
+++ b/data/172/944/349/1/1729443491.geojson
@@ -18,6 +18,9 @@
     "mz:is_current":1,
     "mz:min_zoom":30.0,
     "name:eng_x_preferred":[
+        "Ohio Township"
+    ],
+    "name:eng_x_variant":[
         "Ohio"
     ],
     "src:geom":"whosonfirst",
@@ -44,8 +47,8 @@
         }
     ],
     "wof:id":1729443491,
-    "wof:lastmodified":1613765406,
-    "wof:name":"Ohio",
+    "wof:lastmodified":1632782145,
+    "wof:name":"Ohio Township",
     "wof:parent_id":404525029,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-us",


### PR DESCRIPTION
Guess what, there are _three_ localities_ name Ohio in the state of Ohio. After the [other](https://github.com/whosonfirst-data/whosonfirst-data-admin-us/pull/105) [two](https://github.com/whosonfirst-data/whosonfirst-data-admin-us/pull/102), this PR updates the [Ohio Township](https://en.wikipedia.org/wiki/Ohio_Township,_Clermont_County,_Ohio) in [Clermont County, Ohio](https://en.wikipedia.org/wiki/Clermont_County,_Ohio) [Updating `data/172/944/349/1/1729443491.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)