### PR TITLE
Add cessation date and mark San Francisco, Minnesota ghost town as non-current

### DIFF
--- a/data/172/946/250/7/1729462507.geojson
+++ b/data/172/946/250/7/1729462507.geojson
@@ -48,11 +48,11 @@
     "src:geom_via":"uscensus",
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404511703,
         85633793,
-        102087897
+        102087897,
+        404511703,
+        85688727
     ],
     "wof:breaches":[],
     "wof:coterminous":[
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":1729462507,
-    "wof:lastmodified":1636498523,
+    "wof:lastmodified":1638463383,
     "wof:name":"San Francisco",
     "wof:parent_id":404511703,
     "wof:placetype":"locality",


### PR DESCRIPTION
Updating `data/172/946/250/7/1729462507.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)

Closes https://github.com/whosonfirst-data/whosonfirst-data/issues/1987