### PR TITLE
Add cessation date and mark San Francisco, Minnesota ghost town as non-current

### DIFF
--- a/data/172/946/250/7/1729462507.geojson
+++ b/data/172/946/250/7/1729462507.geojson
@@ -58,6 +58,9 @@
     "wof:coterminous":[
         404511703
     ],
+    "wof:concordances":{
+        "wd:id":"Q7413896"
+    },
     "wof:country":"US",
     "wof:geomhash":"78ef043f3f5055ab925a56db521c8df4",
     "wof:hierarchy":[

--- a/data/172/946/250/7/1729462507.geojson
+++ b/data/172/946/250/7/1729462507.geojson
@@ -2,7 +2,7 @@
   "id": 1729462507,
   "type": "Feature",
   "properties": {
-    "edtf:cessation":"uuuu",
+    "edtf:cessation":"1870",
     "edtf:inception":"uuuu",
     "geom:area":0.007079,
     "geom:area_square_m":62229183.270749,
@@ -15,7 +15,7 @@
     "mps:latitude":44.693051,
     "mps:longitude":-93.709639,
     "mz:hierarchy_label":1,
-    "mz:is_current":1,
+    "mz:is_current":0,
     "mz:min_zoom":30.0,
     "name:ben_x_preferred":[
         "\u09b8\u09be\u09a8 \u09ab\u09cd\u09b0\u09be\u09a8\u09cd\u09b8\u09bf\u09b8\u0995\u09cb"
@@ -48,11 +48,11 @@
     "src:geom_via":"uscensus",
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
-        85688727,
         102191575,
-        404511703,
         85633793,
-        102087897
+        102087897,
+        404511703,
+        85688727
     ],
     "wof:breaches":[],
     "wof:coterminous":[
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":1729462507,
-    "wof:lastmodified":1636498523,
+    "wof:lastmodified":1638463462,
     "wof:name":"San Francisco",
     "wof:parent_id":404511703,
     "wof:placetype":"locality",


### PR DESCRIPTION
Updating `data/172/946/250/7/1729462507.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)

Closes https://github.com/whosonfirst-data/whosonfirst-data/issues/1987