### PR TITLE
Deprecate neighbourhood

### DIFF
--- a/data/858/652/79/85865279.geojson
+++ b/data/858/652/79/85865279.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2021-12-06",
     "edtf:inception":"uuuu",
     "geom:area":0.000091,
     "geom:area_square_m":827876.304981,
@@ -16,7 +17,7 @@
     "mps:latitude":42.327331,
     "mps:longitude":-83.041388,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":0,
     "mz:is_funky":1,
     "mz:is_hard_boundary":0,
     "mz:is_landuse_aoi":0,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":85865279,
-    "wof:lastmodified":1613617974,
+    "wof:lastmodified":1638832959,
     "wof:name":"Detriot",
     "wof:parent_id":85951091,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1515

This PR simply deprecates a bogus "Detroit" neighbourhood in Detroit, MI. Initially I thought this fix would include updates to other surrounding neighbourhoods to fix geometry gaps, but that isn't necessary. Existing neighbourhood coverage in downtown Detroit:

<img width="1194" alt="Screen Shot 2021-12-06 at 3 21 24 PM" src="https://user-images.githubusercontent.com/18567700/144939983-9bd2cccf-8ce2-4885-833f-06de3c58f41e.png">

This feature is in bottom right of this screenshot, overlapping other neighbourhood shapes. Additional work in Detroit can take place through https://github.com/whosonfirst-data/whosonfirst-data/issues/408, no PIP work necessary here.