### PR TITLE
Remove SFO as variant on SF locality

### DIFF
--- a/data/859/225/83/85922583.geojson
+++ b/data/859/225/83/85922583.geojson
@@ -182,7 +182,6 @@
     "name:eng_x_variant":[
         "S Francisco",
         "S. Francisco",
-        "SFO",
         "Sanfran",
         "Sanfrancisco",
         "Frisco"
@@ -800,7 +799,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1608688187,
+    "wof:lastmodified":1644869603,
     "wof:megacity":1,
     "wof:name":"San Francisco",
     "wof:parent_id":102087579,


### PR DESCRIPTION
This PR removes "SFO" as an English variant name on the locality record for San Francisco. 