### PR TITLE
Rename Lexington-Fayette, KY to Lexington, KY

### DIFF
--- a/data/859/471/37/85947137.geojson
+++ b/data/859/471/37/85947137.geojson
@@ -81,10 +81,10 @@
         "\u039b\u03ad\u03be\u03b9\u03bd\u03b3\u03ba\u03c4\u03bf\u03bd"
     ],
     "name:eng_x_preferred":[
-        "Lexington-Fayette"
+        "Lexington"
     ],
     "name:eng_x_variant":[
-        "Lexington"
+        "Lexington-Fayette"
     ],
     "name:epo_x_preferred":[
         "Leksingtono"
@@ -315,8 +315,8 @@
     "wof:belongsto":[
         102191575,
         85633793,
-        85688641,
-        102084695
+        102084695,
+        85688641
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -339,8 +339,8 @@
         }
     ],
     "wof:id":85947137,
-    "wof:lastmodified":1582335582,
-    "wof:name":"Lexington-Fayette",
+    "wof:lastmodified":1646338020,
+    "wof:name":"Lexington",
     "wof:parent_id":102084695,
     "wof:placetype":"locality",
     "wof:population":310797,


### PR DESCRIPTION
I noticed that the city of [Lexington, Kentucky](https://en.wikipedia.org/wiki/Lexington,_Kentucky) has a "preferred" name that appears to be lifted from the combined city/county.

It feels like a situation similar to San Francisco, where the "official" name is a bit too formal for regular use, even though it's technically the most correct.

I've left the name `Lexington-Fayette` in the `variant` name list, since it is still valid.

Updating `data/859/471/37/85947137.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)