### PR TITLE
Fix N San Jose neighbourhood record

### DIFF
--- a/data/110/878/255/3/1108782553.geojson
+++ b/data/110/878/255/3/1108782553.geojson
@@ -22,7 +22,7 @@
     "mz:max_zoom":15.0,
     "mz:min_zoom":13.0,
     "name:eng_x_preferred":[
-        "Berryessa"
+        "North San Jose"
     ],
     "name:eng_x_variant":[
         "N San Jose",
@@ -31,11 +31,8 @@
         "Berryessa",
         "Berryessa District"
     ],
-    "name:fra_x_preferred":[
+    "name:fra_x_variant":[
         "Berryessa"
-    ],
-    "name:und_x_variant":[
-        "Berreyesa"
     ],
     "reversegeo:latitude":37.437322,
     "reversegeo:longitude":-121.9501,
@@ -65,7 +62,7 @@
         }
     ],
     "wof:id":1108782553,
-    "wof:lastmodified":1566624163,
+    "wof:lastmodified":1660248760,
     "wof:name":"North San Jose",
     "wof:parent_id":85922347,
     "wof:placetype":"macrohood",
@@ -73,7 +70,8 @@
     "wof:superseded_by":[],
     "wof:supersedes":[
         85869547,
-        85805881
+        85805881,
+        85882411
     ],
     "wof:tags":[]
 },

--- a/data/858/824/11/85882411.geojson
+++ b/data/858/824/11/85882411.geojson
@@ -2,22 +2,21 @@
   "id": 85882411,
   "type": "Feature",
   "properties": {
-    "edtf:cessation":"uuuu",
+    "edtf:cessation":"2022-08-11",
     "edtf:inception":"uuuu",
     "geom:area":0.003144,
     "geom:area_square_m":30867965.125215,
     "geom:bbox":"-121.9657,37.39491,-121.83915,37.483888",
     "geom:latitude":37.437567,
     "geom:longitude":-121.897262,
-    "gn:id":"",
     "iso:country":"US",
     "lbl:latitude":37.422709,
     "lbl:longitude":-121.912886,
     "lbl:max_zoom":18.0,
     "mps:latitude":37.412948,
     "mps:longitude":-121.938943,
-    "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:hierarchy_label":0,
+    "mz:is_current":1,
     "mz:is_funky":1,
     "mz:is_hard_boundary":0,
     "mz:is_landuse_aoi":0,
@@ -89,17 +88,16 @@
         }
     ],
     "wof:id":85882411,
-    "wof:lang":[
-        "eng"
-    ],
-    "wof:lastmodified":1582337123,
+    "wof:lastmodified":1660248776,
     "wof:name":"North San Jose",
     "wof:parent_id":85922371,
     "wof:placetype":"neighbourhood",
     "wof:population":20742,
     "wof:population_rank":7,
     "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1108782553
+    ],
     "wof:supersedes":[],
     "wof:tags":[],
     "zs:blockids":[


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1994

WOF has two records for "North San Jose" - [this macrohood](https://spelunker.whosonfirst.org/id/1108782553/) and [this neighbourhood](https://spelunker.whosonfirst.org/id/85882411/).

Both records were updated as part of https://github.com/whosonfirst-data/whosonfirst-data/issues/424. The macrohood was created as a new record, and the neighbourhood was clipped to the San Jose locality polygon. Another step should have been added, to supersede the neighbourhood into the new macrohood record, but that work wasn't done.

This PR supersedes the neighbourhood into the macrhood record. I also noticed some name discrepancies in the macrohood record, so I've cleaned those up, too. No PIP work needed, can merge once approved.