### PR TITLE
Correct top-level ids and property types in three airport campus records

### DIFF
--- a/data/174/687/906/7/1746879067.geojson
+++ b/data/174/687/906/7/1746879067.geojson
@@ -1,86 +1,86 @@
 {
-  "id": 102524727,
+  "id": 1746879067,
   "type": "Feature",
   "properties": {
-    "date:cessation_lower": "1945-01-01",
-    "date:cessation_upper": "1945-12-31",
-    "date:inception_lower": "1928-01-01",
-    "date:inception_upper": "1928-12-31",
-    "edtf:cessation": "1945",
-    "edtf:inception": "1928",
-    "geom:area": 0.00013778927899993937,
-    "geom:area_square_m": 1448093.215351,
-    "geom:bbox": "-106.410309,31.786501,-106.385834,31.804399",
-    "geom:latitude": 31.79661345917014,
-    "geom:longitude": -106.3946230737811,
-    "gn:elevation": 1199,
-    "iso:country": "US",
-    "lbl:latitude": 31.797173,
-    "lbl:longitude": -106.392398,
-    "mps:latitude": 31.797173,
-    "mps:longitude": -106.392398,
-    "mz:hierarchy_label": 1,
-    "mz:is_current": 0,
-    "mz:min_zoom": 13,
-    "oa:elevation_ft": "3959",
-    "oa:type": "medium_airport",
-    "src:geom": "woedb",
-    "src:geom_alt": [],
-    "src:lbl_centroid": "mapshaper",
-    "wd:wordcount": 1328,
-    "woe:hierarchy": {
-      "country_id": 23424977,
-      "county_id": 12590076,
-      "planet_id": 1,
-      "state_id": 2347602,
-      "suburb_id": 2380332
+    "date:cessation_lower":"1945-01-01",
+    "date:cessation_upper":"1945-12-31",
+    "date:inception_lower":"1928-01-01",
+    "date:inception_upper":"1928-12-31",
+    "edtf:cessation":"1945",
+    "edtf:inception":"1928",
+    "geom:area":0.000138,
+    "geom:area_square_m":1448093.215351,
+    "geom:bbox":"-106.410309,31.786501,-106.385834,31.804399",
+    "geom:latitude":31.796613,
+    "geom:longitude":-106.394623,
+    "gn:elevation":1199,
+    "iso:country":"US",
+    "lbl:latitude":31.797173,
+    "lbl:longitude":-106.392398,
+    "mps:latitude":31.797173,
+    "mps:longitude":-106.392398,
+    "mz:hierarchy_label":1,
+    "mz:is_current":0,
+    "mz:min_zoom":13,
+    "oa:elevation_ft":"3959",
+    "oa:type":"medium_airport",
+    "src:geom":"woedb",
+    "src:geom_alt":[],
+    "src:lbl_centroid":"mapshaper",
+    "wd:wordcount":1328,
+    "woe:hierarchy":{
+        "country_id":23424977,
+        "county_id":12590076,
+        "planet_id":1,
+        "state_id":2347602,
+        "suburb_id":2380332
     },
-    "wof:belongsto": [
-      85811021,
-      102191575,
-      85633793,
-      101724863,
-      102085989,
-      85688753
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102085989,
+        101724863,
+        85811021,
+        85688753
     ],
-    "wof:breaches": [],
-    "wof:concordances": {
-      "faa:code": "ELP",
-      "iata:code": "ELP",
-      "icao:code": "KELP",
-      "wd:id": "Q1231062"
+    "wof:breaches":[],
+    "wof:concordances":{
+        "faa:code":"ELP",
+        "iata:code":"ELP",
+        "icao:code":"KELP",
+        "wd:id":"Q1231062"
     },
-    "wof:country": "US",
-    "wof:created": 1640289694,
-    "wof:geomhash": "05d71108559eb3d3ff60fa16cc415956",
-    "wof:hierarchy": [
-      {
-        "campus_id": 1746879067,
-        "continent_id": 102191575,
-        "country_id": 85633793,
-        "county_id": 102085989,
-        "locality_id": 101724863,
-        "neighbourhood_id": 85811021,
-        "region_id": 85688753
-      }
+    "wof:country":"US",
+    "wof:created":1640289694,
+    "wof:geomhash":"05d71108559eb3d3ff60fa16cc415956",
+    "wof:hierarchy":[
+        {
+            "campus_id":1746879067,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102085989,
+            "locality_id":101724863,
+            "neighbourhood_id":85811021,
+            "region_id":85688753
+        }
     ],
-    "wof:id": 1746879067,
-    "wof:lastmodified": 1640289978,
-    "wof:name": "El Paso Municipal Airport",
-    "wof:parent_id": 85811021,
-    "wof:placetype": "campus",
-    "wof:repo": "whosonfirst-data-admin-us",
-    "wof:superseded_by": [],
-    "wof:supersedes": [],
-    "wof:tags": [
-      "airport"
+    "wof:id":1746879067,
+    "wof:lastmodified":1678138017,
+    "wof:name":"El Paso Municipal Airport",
+    "wof:parent_id":85811021,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[
+        "airport"
     ]
-  },
+},
   "bbox": [
     -106.410309,
     31.786501,
     -106.385834,
     31.804399
-  ],
-  "geometry": {"coordinates":[[[[-106.396858,31.794853],[-106.402092,31.795525],[-106.403336,31.788834],[-106.404549,31.787727],[-106.407501,31.786501],[-106.410004,31.787601],[-106.410309,31.78896],[-106.404282,31.788532],[-106.403099,31.796328],[-106.399239,31.797859],[-106.397438,31.800558],[-106.398003,31.804399],[-106.392845,31.802309],[-106.391083,31.802673],[-106.385834,31.800554],[-106.386169,31.7985],[-106.388512,31.793118],[-106.389557,31.7904],[-106.391426,31.791731],[-106.394089,31.792318],[-106.395035,31.792278],[-106.395836,31.793667],[-106.396858,31.794853]]]],"type":"MultiPolygon"}
+],
+  "geometry": {"coordinates":[[[[-106.39685799999999,31.794853],[-106.402092,31.795525],[-106.403336,31.788834],[-106.404549,31.787727],[-106.407501,31.786501],[-106.410004,31.787601],[-106.410309,31.78896],[-106.40428199999999,31.788532],[-106.403099,31.796328],[-106.39923899999999,31.797859],[-106.39743799999999,31.800558],[-106.398003,31.804399],[-106.39284499999999,31.802309],[-106.39108299999999,31.802673],[-106.385834,31.800554],[-106.386169,31.7985],[-106.38851200000001,31.793118],[-106.389557,31.7904],[-106.391426,31.791731],[-106.39408899999999,31.792318],[-106.39503499999999,31.792278],[-106.395836,31.793667],[-106.39685799999999,31.794853]]]],"type":"MultiPolygon"}
 }

--- a/data/174/690/480/3/1746904803.geojson
+++ b/data/174/690/480/3/1746904803.geojson
@@ -1,84 +1,84 @@
 {
-  "id": 102531473,
+  "id": 1746904803,
   "type": "Feature",
   "properties": {
-    "date:cessation_lower": "1960-01-01",
-    "date:cessation_upper": "1960-12-31",
-    "date:inception_lower": "1930-01-01",
-    "date:inception_upper": "1939-12-31",
-    "edtf:cessation": "1960",
-    "edtf:inception": "",
-    "geom:area": 0.000003055427999997117,
-    "geom:area_square_m": 33427.887356,
-    "geom:bbox": "-97.502457,27.774626,-97.499542,27.776386",
-    "geom:latitude": 27.775311919936584,
-    "geom:longitude": -97.50066787625302,
-    "gn:elevation": 12,
-    "iso:country": "US",
-    "lbl:latitude": 27.775295,
-    "lbl:longitude": -97.500644,
-    "mps:latitude": 27.775295,
-    "mps:longitude": -97.500644,
-    "mz:hierarchy_label": 1,
-    "mz:is_approximate": "1",
-    "mz:is_current": "0",
-    "mz:min_zoom": 13,
-    "oa:elevation_ft": "44",
-    "oa:type": "large_airport",
-    "src:geom": "woedb",
-    "src:geom_alt": [],
-    "src:lbl_centroid": "mapshaper",
-    "wd:wordcount": 3319,
-    "woe:hierarchy": {
-      "country_id": 23424977,
-      "county_id": 12590184,
-      "planet_id": 1,
-      "state_id": 2347602,
-      "suburb_id": 2380912
+    "date:cessation_lower":"1960-01-01",
+    "date:cessation_upper":"1960-12-31",
+    "date:inception_lower":"1930-01-01",
+    "date:inception_upper":"1939-12-31",
+    "edtf:cessation":"1960",
+    "edtf:inception":"",
+    "geom:area":0.000003,
+    "geom:area_square_m":33427.887356,
+    "geom:bbox":"-97.502457,27.774626,-97.499542,27.776386",
+    "geom:latitude":27.775312,
+    "geom:longitude":-97.500668,
+    "gn:elevation":12,
+    "iso:country":"US",
+    "lbl:latitude":27.775295,
+    "lbl:longitude":-97.500644,
+    "mps:latitude":27.775295,
+    "mps:longitude":-97.500644,
+    "mz:hierarchy_label":1,
+    "mz:is_approximate":1,
+    "mz:is_current":0,
+    "mz:min_zoom":13,
+    "oa:elevation_ft":"44",
+    "oa:type":"large_airport",
+    "src:geom":"woedb",
+    "src:geom_alt":[],
+    "src:lbl_centroid":"mapshaper",
+    "wd:wordcount":3319,
+    "woe:hierarchy":{
+        "country_id":23424977,
+        "county_id":12590184,
+        "planet_id":1,
+        "state_id":2347602,
+        "suburb_id":2380912
     },
-    "wof:belongsto": [
-      85873327,
-      102191575,
-      85633793,
-      101724325,
-      102081441,
-      85688753
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081441,
+        101724325,
+        85873327,
+        85688753
     ],
-    "wof:breaches": [],
-    "wof:concordances": {},
-    "wof:country": "US",
-    "wof:created": 1640731864,
-    "wof:geomhash": "369c6658c14c95828bc3511068986617",
-    "wof:hierarchy": [
-      {
-        "campus_id": 1746904803,
-        "continent_id": 102191575,
-        "country_id": 85633793,
-        "county_id": 102081441,
-        "locality_id": 101724325,
-        "neighbourhood_id": 85873327,
-        "region_id": 85688753
-      }
+    "wof:breaches":[],
+    "wof:concordances":{},
+    "wof:country":"US",
+    "wof:created":1640731864,
+    "wof:geomhash":"369c6658c14c95828bc3511068986617",
+    "wof:hierarchy":[
+        {
+            "campus_id":1746904803,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081441,
+            "locality_id":101724325,
+            "neighbourhood_id":85873327,
+            "region_id":85688753
+        }
     ],
-    "wof:id": 1746904803,
-    "wof:lastmodified": 1640732019,
-    "wof:name": "Cliff Maus Field",
-    "wof:parent_id": 85873327,
-    "wof:placetype": "campus",
-    "wof:repo": "whosonfirst-data-admin-us",
-    "wof:superseded_by": [],
-    "wof:supersedes": [
-      1746904805
+    "wof:id":1746904803,
+    "wof:lastmodified":1678138022,
+    "wof:name":"Cliff Maus Field",
+    "wof:parent_id":85873327,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[],
+    "wof:supersedes":[
+        1746904805
     ],
-    "wof:tags": [
-      "airport"
+    "wof:tags":[
+        "airport"
     ]
-  },
+},
   "bbox": [
     -97.502457,
     27.774626,
     -97.499542,
     27.776386
-  ],
-  "geometry": {"coordinates":[[[[-97.501518,27.774626],[-97.502457,27.775229],[-97.499542,27.776386],[-97.499626,27.774658],[-97.501518,27.774626]]]],"type":"MultiPolygon"}
+],
+  "geometry": {"coordinates":[[[[-97.501518,27.774626],[-97.50245700000001,27.775229],[-97.49954200000001,27.776386],[-97.49962600000001,27.774658],[-97.501518,27.774626]]]],"type":"MultiPolygon"}
 }

--- a/data/174/690/480/5/1746904805.geojson
+++ b/data/174/690/480/5/1746904805.geojson
@@ -1,84 +1,84 @@
 {
-  "id": 102531473,
+  "id": 1746904805,
   "type": "Feature",
   "properties": {
-    "date:cessation_lower": "1960-01-01",
-    "date:cessation_upper": "1960-12-31",
-    "date:inception_lower": "1930-01-01",
-    "date:inception_upper": "1939-12-31",
-    "edtf:cessation": "1960",
-    "edtf:inception": "",
-    "geom:area": 0.000003055427999997117,
-    "geom:area_square_m": 33427.887356,
-    "geom:bbox": "-97.502457,27.774626,-97.499542,27.776386",
-    "geom:latitude": 27.775311919936584,
-    "geom:longitude": -97.50066787625302,
-    "gn:elevation": 12,
-    "iso:country": "US",
-    "lbl:latitude": 27.775295,
-    "lbl:longitude": -97.500644,
-    "mps:latitude": 27.775295,
-    "mps:longitude": -97.500644,
-    "mz:hierarchy_label": 1,
-    "mz:is_approximate": "1",
-    "mz:is_current": 0,
-    "mz:min_zoom": 13,
-    "oa:elevation_ft": "44",
-    "oa:type": "large_airport",
-    "src:geom": "woedb",
-    "src:geom_alt": [],
-    "src:lbl_centroid": "mapshaper",
-    "wd:wordcount": 3319,
-    "woe:hierarchy": {
-      "country_id": 23424977,
-      "county_id": 12590184,
-      "planet_id": 1,
-      "state_id": 2347602,
-      "suburb_id": 2380912
+    "date:cessation_lower":"1960-01-01",
+    "date:cessation_upper":"1960-12-31",
+    "date:inception_lower":"1930-01-01",
+    "date:inception_upper":"1939-12-31",
+    "edtf:cessation":"1960",
+    "edtf:inception":"",
+    "geom:area":0.000003,
+    "geom:area_square_m":33427.887356,
+    "geom:bbox":"-97.502457,27.774626,-97.499542,27.776386",
+    "geom:latitude":27.775312,
+    "geom:longitude":-97.500668,
+    "gn:elevation":12,
+    "iso:country":"US",
+    "lbl:latitude":27.775295,
+    "lbl:longitude":-97.500644,
+    "mps:latitude":27.775295,
+    "mps:longitude":-97.500644,
+    "mz:hierarchy_label":1,
+    "mz:is_approximate":1,
+    "mz:is_current":0,
+    "mz:min_zoom":13,
+    "oa:elevation_ft":"44",
+    "oa:type":"large_airport",
+    "src:geom":"woedb",
+    "src:geom_alt":[],
+    "src:lbl_centroid":"mapshaper",
+    "wd:wordcount":3319,
+    "woe:hierarchy":{
+        "country_id":23424977,
+        "county_id":12590184,
+        "planet_id":1,
+        "state_id":2347602,
+        "suburb_id":2380912
     },
-    "wof:belongsto": [
-      85873327,
-      102191575,
-      85633793,
-      101724325,
-      102081441,
-      85688753
+    "wof:belongsto":[
+        102191575,
+        85633793,
+        102081441,
+        101724325,
+        85873327,
+        85688753
     ],
-    "wof:breaches": [],
-    "wof:concordances": {},
-    "wof:country": "US",
-    "wof:created": 1640731864,
-    "wof:geomhash": "369c6658c14c95828bc3511068986617",
-    "wof:hierarchy": [
-      {
-        "campus_id": 1746904805,
-        "continent_id": 102191575,
-        "country_id": 85633793,
-        "county_id": 102081441,
-        "locality_id": 101724325,
-        "neighbourhood_id": 85873327,
-        "region_id": 85688753
-      }
+    "wof:breaches":[],
+    "wof:concordances":{},
+    "wof:country":"US",
+    "wof:created":1640731864,
+    "wof:geomhash":"369c6658c14c95828bc3511068986617",
+    "wof:hierarchy":[
+        {
+            "campus_id":1746904805,
+            "continent_id":102191575,
+            "country_id":85633793,
+            "county_id":102081441,
+            "locality_id":101724325,
+            "neighbourhood_id":85873327,
+            "region_id":85688753
+        }
     ],
-    "wof:id": 1746904805,
-    "wof:lastmodified": 1640732058,
-    "wof:name": "Corpus Christi Municipal Airport",
-    "wof:parent_id": 85873327,
-    "wof:placetype": "campus",
-    "wof:repo": "whosonfirst-data-admin-us",
-    "wof:superseded_by": [
-      1746904803
+    "wof:id":1746904805,
+    "wof:lastmodified":1678138026,
+    "wof:name":"Corpus Christi Municipal Airport",
+    "wof:parent_id":85873327,
+    "wof:placetype":"campus",
+    "wof:repo":"whosonfirst-data-admin-us",
+    "wof:superseded_by":[
+        1746904803
     ],
-    "wof:supersedes": [],
-    "wof:tags": [
-      "airport"
+    "wof:supersedes":[],
+    "wof:tags":[
+        "airport"
     ]
-  },
+},
   "bbox": [
     -97.502457,
     27.774626,
     -97.499542,
     27.776386
-  ],
-  "geometry": {"coordinates":[[[[-97.501518,27.774626],[-97.502457,27.775229],[-97.499542,27.776386],[-97.499626,27.774658],[-97.501518,27.774626]]]],"type":"MultiPolygon"}
+],
+  "geometry": {"coordinates":[[[[-97.501518,27.774626],[-97.50245700000001,27.775229],[-97.49954200000001,27.776386],[-97.49962600000001,27.774658],[-97.501518,27.774626]]]],"type":"MultiPolygon"}
 }


### PR DESCRIPTION
Will fix https://github.com/whosonfirst-data/whosonfirst-data/issues/2001 and https://github.com/whosonfirst-data/whosonfirst-data/issues/2002.

Crawling the US repo, I was reminded of these id issues.. opening this PR to correct them, shouldn't require any additional work.

**Changes**:
- Corrects the top-level `id` property in three campus records in this repo to match the `wof:id` and path
- Converts a handful of `mz` properties from strings to integers
- Exportifies each updated record (this is the reason for the spacing / formatting changes)

**Number of records changed**: 3