### PR TITLE
Fix USA names

### DIFF
--- a/data/856/337/93/85633793.geojson
+++ b/data/856/337/93/85633793.geojson
@@ -272,9 +272,6 @@
         "USA"
     ],
     "name:dan_x_preferred":[
-        "USA"
-    ],
-    "name:dan_x_variant":[
         "Amerikas Forenede Stater"
     ],
     "name:deu_at_x_preferred":[
@@ -369,10 +366,10 @@
         "Estaus Unius"
     ],
     "name:fao_x_preferred":[
-        "USA"
+        "Sambandsr\u00edki Amerika"
     ],
     "name:fao_x_variant":[
-        "Sambandsr\u00edki Amerika"
+        "USA"
     ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0627\u0644\u0627\u062a \u0645\u062a\u062d\u062f\u0647 \u0622\u0645\u0631\u06cc\u06a9\u0627"
@@ -879,25 +876,26 @@
         "USA"
     ],
     "name:nno_x_preferred":[
-        "USA"
+        "Dei Amerikanske Sambandsstatane"
     ],
     "name:nno_x_variant":[
-        "Dei amerikanske sambandsstatane",
         "Sambandsstatane"
     ],
     "name:nob_x_colloquial":[
         "USA"
     ],
     "name:nob_x_preferred":[
-        "Amerikas forente stater"
+        "Amerikas Forente Stater"
     ],
     "name:nob_x_variant":[
-        "Forente stater",
+        "Amerikas Forente Stater",
+        "Forente stater"
+    ],
+    "name:nor_x_colloquial":[
         "USA"
     ],
     "name:nor_x_preferred":[
-        "Amerikas Forente Stater",
-        "USA"
+        "Amerikas Forente Stater"
     ],
     "name:nov_x_preferred":[
         "Unionati States de Amerika"
@@ -1175,10 +1173,9 @@
         "USA"
     ],
     "name:swe_x_preferred":[
-        "USA"
+        "Amerikas F\u00f6renta Stater"
     ],
     "name:swe_x_variant":[
-        "Amerikas F\u00f6renta Stater",
         "F\u00f6renta Staterna"
     ],
     "name:szl_x_preferred":[
@@ -1604,7 +1601,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1617828565,
+    "wof:lastmodified":1679939233,
     "wof:name":"United States",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix https://github.com/whosonfirst-data/whosonfirst-data/issues/2037

This PR updates names in a handful of languages on the United States country record, swapping "USA" out for the full name translation.

No PIP work needed, can merge as-is.

**Number of records updated**: 1