### PR TITLE
Add concordance to nyc record

### DIFF
--- a/data/859/775/39/85977539.geojson
+++ b/data/859/775/39/85977539.geojson
@@ -1102,6 +1102,7 @@
         "ne:id":1159151575,
         "nyt:id":"N63718991197345770861",
         "qs_pg:id":826077,
+        "uscensus:geoid":"3651000",
         "wd:id":"Q60",
         "wk:page":"New York City"
     },
@@ -1157,7 +1158,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1613780442,
+    "wof:lastmodified":1681154887,
     "wof:megacity":1,
     "wof:name":"New York",
     "wof:parent_id":-4,


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-us/pull/143

Adds a concordance to the locality record for NYC.