### PR TITLE
Update Place Maplewood

### DIFF
--- a/data/858/657/55/85865755.geojson
+++ b/data/858/657/55/85865755.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.001026,
     "geom:area_square_m":9435556.808674,
-    "geom:bbox":"-87.7271853627,41.9098866902,-87.6872206971,41.9393272515",
+    "geom:bbox":"-87.727185362663,41.9098866901866,-87.6872206970523,41.9393272514622",
     "geom:latitude":41.92347,
     "geom:longitude":-87.708651,
     "gn:elevation":182,
@@ -27,6 +27,9 @@
     "mz:note":"OLD  village",
     "mz:tier_locality":6,
     "mz:tier_metro":1,
+    "name:eng_x_historical":[
+        "Maplewood"
+    ],
     "name:eng_x_preferred":[
         "Logan Square"
     ],
@@ -87,12 +90,12 @@
     "src:lbl_centroid":"mz",
     "src:population":"zetashapes",
     "wof:belongsto":[
-        102191575,
-        404496273,
-        85633793,
-        85940195,
         958020405,
+        102191575,
+        85633793,
         102084317,
+        404496273,
+        85940195,
         85688697
     ],
     "wof:breaches":[],
@@ -126,8 +129,8 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582336871,
-    "wof:name":"Maplewood",
+    "wof:lastmodified":1691614248,
+    "wof:name":"Logan Square",
     "wof:parent_id":958020405,
     "wof:placetype":"neighbourhood",
     "wof:population":19582,


### PR DESCRIPTION
I noticed that a popular neighborhood in Chicago, "Logan Square", has its `name` set as "Maplewood". Maplewood is a historical name that is no longer in use—the official name for this neighborhood in Chicago is "Logan Square". Thanks!

Updating `data/858/657/55/85865755.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)