### PR TITLE
Add example wof:concordances_x_official key/value

### DIFF
--- a/data/856/886/37/85688637.geojson
+++ b/data/856/886/37/85688637.geojson
@@ -894,8 +894,9 @@
         "uscensus:geoid":"06",
         "wd:id":"Q99"
     },
-    "wof:concordances_x_official":[
-        "uscensus:geoid"
+    "wof:concordances_official":"uscensus:geoid",
+    "wof:concordances_official_alt":[
+        "iso:id"
     ],
     "wof:country":"US",
     "wof:geom_alt":[

--- a/data/856/886/37/85688637.geojson
+++ b/data/856/886/37/85688637.geojson
@@ -894,6 +894,9 @@
         "uscensus:geoid":"06",
         "wd:id":"Q99"
     },
+    "wof:concordances_x_official":[
+        "uscensus:geoid"
+    ],
     "wof:country":"US",
     "wof:geom_alt":[
         "uscensus-display-terrestrial-zoom-10"
@@ -915,7 +918,7 @@
         "spa",
         "haw"
     ],
-    "wof:lastmodified":1690886571,
+    "wof:lastmodified":1695146122,
     "wof:name":"California",
     "wof:parent_id":85633793,
     "wof:placetype":"region",


### PR DESCRIPTION
Prepping for shapefile export in https://github.com/pelias/wof/pull/49 to enable ad hoc data joins against official demographic data from national statistical agencies for CARTO.

Right now we have a big bag of concordances, but we don't know which is significant for local users in a given country. This solves that by adding `wof:concordances_x_official` which follows the convention we have already for `wof:lang_x_official`.

I'll add a properties documentation change PR shortly.

Part of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164.