### PR TITLE
Update 85872959.geojson

### DIFF
--- a/data/858/729/59/85872959.geojson
+++ b/data/858/729/59/85872959.geojson
@@ -91,7 +91,7 @@
         ""
     ],
     "name:eng_x_preferred":[
-        "Aurora District"
+        "Aurora"
     ],
     "name:eng_x_variant":[
         "Aurora"
@@ -322,7 +322,7 @@
     "qs:local_max":1082,
     "qs:local_sum":7727,
     "qs:localhoods":23,
-    "qs:name":"Aurora District",
+    "qs:name":"Aurora",
     "qs:name_adm0":"United States",
     "qs:name_adm1":"Colorado",
     "qs:name_local":"Aurora",
@@ -379,7 +379,7 @@
     ],
     "wof:lastmodified":1690887755,
     "wof:megacity":0,
-    "wof:name":"Aurora District",
+    "wof:name":"Aurora",
     "wof:parent_id":85929235,
     "wof:placetype":"neighbourhood",
     "wof:population":325078,

--- a/data/858/729/59/85872959.geojson
+++ b/data/858/729/59/85872959.geojson
@@ -94,7 +94,7 @@
         "Aurora"
     ],
     "name:eng_x_variant":[
-        "Aurora"
+        "Aurora District"
     ],
     "name:epo_x_preferred":[
         "Aurora"
@@ -322,7 +322,7 @@
     "qs:local_max":1082,
     "qs:local_sum":7727,
     "qs:localhoods":23,
-    "qs:name":"Aurora",
+    "qs:name":"Aurora District",
     "qs:name_adm0":"United States",
     "qs:name_adm1":"Colorado",
     "qs:name_local":"Aurora",


### PR DESCRIPTION
Removing 'District' from label for City of Aurora, which is not a term used to describe this area. As this data flows into systems such as Geocode.Earth, which is used by our School Choice Vendor, an address within Aurora shows a result of 'Aurora District', which causes additional confusion in that it suggests the Aurora School District, which is not the correct name either.