### PR TITLE
Update Place Little Poland

### DIFF
--- a/data/858/230/59/85823059.geojson
+++ b/data/858/230/59/85823059.geojson
@@ -122,11 +122,11 @@
     "src:lbl_centroid":"mz",
     "src:population":"zetashapes",
     "wof:belongsto":[
+        421205765,
         102191575,
         85633793,
-        85977539,
-        421205765,
         102082361,
+        85977539,
         85688543
     ],
     "wof:breaches":[],
@@ -162,8 +162,8 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1690887574,
-    "wof:name":"Little Poland",
+    "wof:lastmodified":1708440268,
+    "wof:name":"Greenpoint",
     "wof:parent_id":421205765,
     "wof:placetype":"neighbourhood",
     "wof:population":37393,

--- a/data/858/230/59/85823059.geojson
+++ b/data/858/230/59/85823059.geojson
@@ -32,6 +32,9 @@
     "name:eng_x_preferred":[
         "Greenpoint"
     ],
+    "name:eng_x_historical":[
+        "Little Poland"
+    ],
     "name:eng_x_variant":[
         "Little Poland"
     ],


### PR DESCRIPTION
Updating `data/858/230/59/85823059.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)

Neighbourhood is predominantly known as "Greenpoint," rather than "Little Poland". And while [neighbourhoods are absolutely an expression of consensual hallucinations](https://whosonfirst.org/blog/2016/08/15/mapping-with-bias/), it is worth documenting why a change in primary placename be made. Greenpoint is home to the second-largest Polish community in the United States of America, so this is not intended to denegrate or minimize the Polish community's incredible contributions to, historical presence in, and active leadership in the neighbourhood, but rather to reflect the most common name in downstream gazetteer uses.

[Wikipedia: Greenpoint, Brooklyn](https://en.wikipedia.org/wiki/Greenpoint,_Brooklyn) does prominently note in the article's introduction that the neighbourhood is "often referred to as Little Poland" (and is a prominent placement on the [Little Poland disambiguation page](https://en.wikipedia.org/wiki/Little_Poland). However, the rest of the article continues to refer to the district as Greenpoint.

A fairer way to judge is likely in documentation of how the neighbourhood refers to itself.

- The local newspaper (now a free monthly) is the [Greenpoint Gazette](https://brooklyneagle.com/greenpoint-gazette/)

Local Electeds all refer to their districts as Greenpoint:
- [State Assembly](https://nyassembly.gov/mem/Emily-Gallagher): `Emily Gallagher represents the North Brooklyn neighborhoods of Greenpoint and Williamsburg in the New York State Assembly`
- [City Council](https://council.nyc.gov/district-33/): `Born and raised in the 33rd Council District, Lincoln was raised by and has spent his whole life working with the communities that make up the district – from Greenpoint to Brooklyn Heights and from Boerum Hill to Williamsburg.`
- [State Senate (campaign site)](https://www.gonzalezforny.com/): `I'm running in the new state Senate District 59, which includes the neighborhoods of Astoria, Long Island City, Greenpoint, Kips Bay, StuyTown, Gramercy, Williamsburg and Murray Hill.`

It's not word-on-the-street, but Google Trends for ["Little Poland, Greenpoint" for searches from within NYC](https://trends.google.com/trends/explore?date=2019-02-03%202024-03-03&geo=US-NY-501&q=Little%20Poland,Greenpoint&hl=en) is 50-70x less for "Little Poland" than "Greenpoint".
![image](https://github.com/whosonfirst-data/whosonfirst-data-admin-us/assets/227472/e0a622e0-737e-411e-84ff-bcaf16493fc8)

And it shouldn't be a deciding factor here, but Google Maps' primary name is Greenpoint, with an altname of "Little Poland" that allows it to show up in search results.

Should additional documentation or community input be requested, I'm happy to solicit it.