### PR TITLE
Update BoCoCa macrohood label position, src property

### DIFF
--- a/data/102/147/495/102147495.geojson
+++ b/data/102/147/495/102147495.geojson
@@ -2,159 +2,160 @@
   "id": 102147495,
   "type": "Feature",
   "properties": {
-    "edtf:cessation":"uuuu",
-    "edtf:inception":"uuuu",
-    "geom:area":0.000211,
-    "geom:area_square_m":1981068.145888,
-    "geom:bbox":"-74.0034140274,40.67218,-73.978026,40.6915760529",
-    "geom:latitude":40.683926,
-    "geom:longitude":-73.993051,
-    "gn:id":"",
-    "iso:country":"US",
-    "lbl:latitude":40.680824,
-    "lbl:longitude":-74.003114,
-    "lbl:max_zoom":15.0,
-    "mps:latitude":40.684804,
-    "mps:longitude":-73.995167,
-    "mz:hierarchy_label":1,
-    "mz:is_current":1,
-    "mz:is_funky":0,
-    "mz:is_hard_boundary":0,
-    "mz:is_landuse_aoi":0,
-    "mz:is_official":0,
-    "mz:max_zoom":0.0,
-    "mz:min_zoom":15.0,
-    "mz:tier_metro":1,
-    "name:eng_x_preferred":[
-        "BoCoCa"
+    "edtf:cessation": "",
+    "edtf:inception": "",
+    "geom:area": 0.0002112739591933823,
+    "geom:area_square_m": 1981068.145888,
+    "geom:bbox": "-74.003414,40.672180,-73.978026,40.691576",
+    "geom:latitude": 40.6839262842279,
+    "geom:longitude": -73.99305138232818,
+    "gn:id": "",
+    "iso:country": "US",
+    "lbl:latitude": 40.684804,
+    "lbl:longitude": -73.995167,
+    "lbl:max_zoom": 15,
+    "mps:latitude": 40.684804,
+    "mps:longitude": -73.995167,
+    "mz:hierarchy_label": 1,
+    "mz:is_current": 1,
+    "mz:is_funky": 0,
+    "mz:is_hard_boundary": 0,
+    "mz:is_landuse_aoi": 0,
+    "mz:is_official": 0,
+    "mz:max_zoom": 0,
+    "mz:min_zoom": 15,
+    "mz:tier_metro": 1,
+    "name:eng_x_preferred": [
+      "BoCoCa"
     ],
-    "name:nld_x_preferred":[
-        "BoCoCa"
+    "name:nld_x_preferred": [
+      "BoCoCa"
     ],
-    "name:por_x_preferred":[
-        "BoCoCa"
+    "name:por_x_preferred": [
+      "BoCoCa"
     ],
-    "name:spa_x_preferred":[
-        "BoCoCa"
+    "name:spa_x_preferred": [
+      "BoCoCa"
     ],
-    "qs:gn_adm0_cc":"US",
-    "qs:gn_id":0,
-    "qs:gn_local":5128581,
-    "qs:gn_nam_loc":"New York, New York, US",
-    "qs:gn_namadm1":"NY",
-    "qs:local_max":59970,
-    "qs:local_sum":2486608,
-    "qs:localhoods":427,
-    "qs:name":"BoCoCa",
-    "qs:name_adm0":"United States",
-    "qs:name_adm1":"New York",
-    "qs:name_adm2":"Brooklyn",
-    "qs:name_local":"New York",
-    "qs:photo_max":691,
-    "qs:photo_sum":5302,
-    "qs:placetype":"Suburb",
-    "qs:quad_count":85,
-    "qs:woe_adm0":23424977,
-    "qs:woe_adm1":2347591,
-    "qs:woe_adm2":12589335,
-    "qs:woe_funk":"Grouping neighborhood",
-    "qs:woe_lau":0,
-    "qs:woe_local":2459115,
-    "qs:woe_ver":"7.10.0",
-    "reversegeo:latitude":40.684804,
-    "reversegeo:longitude":-73.995167,
-    "src:geom":"mz",
-    "src:geom_alt":[
-        "zetashapes",
-        "quattroshapes"
+    "qs:gn_adm0_cc": "US",
+    "qs:gn_id": 0,
+    "qs:gn_local": 5128581,
+    "qs:gn_nam_loc": "New York, New York, US",
+    "qs:gn_namadm1": "NY",
+    "qs:local_max": 59970,
+    "qs:local_sum": 2486608,
+    "qs:localhoods": 427,
+    "qs:name": "BoCoCa",
+    "qs:name_adm0": "United States",
+    "qs:name_adm1": "New York",
+    "qs:name_adm2": "Brooklyn",
+    "qs:name_local": "New York",
+    "qs:photo_max": 691,
+    "qs:photo_sum": 5302,
+    "qs:placetype": "Suburb",
+    "qs:quad_count": 85,
+    "qs:woe_adm0": 23424977,
+    "qs:woe_adm1": 2347591,
+    "qs:woe_adm2": 12589335,
+    "qs:woe_funk": "Grouping neighborhood",
+    "qs:woe_lau": 0,
+    "qs:woe_local": 2459115,
+    "qs:woe_ver": "7.10.0",
+    "reversegeo:latitude": 40.684804,
+    "reversegeo:longitude": -73.995167,
+    "src:geom": "mz",
+    "src:geom_alt": [
+      "zetashapes",
+      "quattroshapes"
     ],
-    "src:lbl_centroid":"mz",
-    "src:population":"zetashapes",
-    "wd:wordcount":319,
-    "wof:belongsto":[
-        85688543,
-        102191575,
-        85633793,
-        85977539,
-        421205765,
-        102082361
+    "src:lbl_centroid": "mapshaper",
+    "src:population": "zetashapes",
+    "wd:wordcount": 319,
+    "wof:belongsto": [
+      85688543,
+      102191575,
+      85633793,
+      85977539,
+      421205765,
+      102082361
     ],
-    "wof:breaches":[
-        102061079
+    "wof:breaches": [
+      102061079
     ],
-    "wof:concordances":{
-        "gp:id":55992163,
-        "qs_pg:id":384671,
-        "wd:id":"Q4931044"
+    "wof:concordances": {
+      "gp:id": 55992163,
+      "qs_pg:id": 384671,
+      "wd:id": "Q4931044"
     },
-    "wof:country":"US",
-    "wof:geom_alt":[
-        "zetashapes",
-        "quattroshapes"
+    "wof:country": "US",
+    "wof:created": 1721798999,
+    "wof:geom_alt": [
+      "zetashapes",
+      "quattroshapes"
     ],
-    "wof:geomhash":"fd8837607483a01b909b6436bfa53dbc",
-    "wof:hierarchy":[
-        {
-            "borough_id":421205765,
-            "continent_id":102191575,
-            "country_id":85633793,
-            "county_id":102082361,
-            "locality_id":85977539,
-            "macrohood_id":102147495,
-            "region_id":85688543
-        }
+    "wof:geomhash": "fd8837607483a01b909b6436bfa53dbc",
+    "wof:hierarchy": [
+      {
+        "borough_id": 421205765,
+        "continent_id": 102191575,
+        "country_id": 85633793,
+        "county_id": 102082361,
+        "locality_id": 85977539,
+        "macrohood_id": 102147495,
+        "region_id": 85688543
+      }
     ],
-    "wof:id":102147495,
-    "wof:lastmodified":1582335217,
-    "wof:name":"BoCoCa",
-    "wof:parent_id":421205765,
-    "wof:placetype":"macrohood",
-    "wof:population":8744,
-    "wof:population_rank":5,
-    "wof:repo":"whosonfirst-data-admin-us",
-    "wof:superseded_by":[],
-    "wof:supersedes":[
-        85892915
+    "wof:id": 102147495,
+    "wof:lastmodified": 1721798999,
+    "wof:name": "BoCoCa",
+    "wof:parent_id": 421205765,
+    "wof:placetype": "macrohood",
+    "wof:population": 8744,
+    "wof:population_rank": 5,
+    "wof:repo": "whosonfirst-data-admin-us",
+    "wof:superseded_by": [],
+    "wof:supersedes": [
+      85892915
     ],
-    "wof:tags":[],
-    "zs:blockids":[
-        360470067002001,
-        360470077004000,
-        360470077001002,
-        360470077004002,
-        360470075005002,
-        360470075002003,
-        360470065004000,
-        360470065002000,
-        360470077004001,
-        360470075004001,
-        360470065005000,
-        360470067003000,
-        360470069002002,
-        360470065001000,
-        360470069003000,
-        360470075001002,
-        360470075002002,
-        360470067002000,
-        360470075005001,
-        360470075005000,
-        360470069003001,
-        360470075003002,
-        360470065003000,
-        360470069002000,
-        360470069002001,
-        360470069003002,
-        360470075001003,
-        360470075004000
+    "wof:tags": [],
+    "zs:blockids": [
+      360470067002001,
+      360470077004000,
+      360470077001002,
+      360470077004002,
+      360470075005002,
+      360470075002003,
+      360470065004000,
+      360470065002000,
+      360470077004001,
+      360470075004001,
+      360470065005000,
+      360470067003000,
+      360470069002002,
+      360470065001000,
+      360470069003000,
+      360470075001002,
+      360470075002002,
+      360470067002000,
+      360470075005001,
+      360470075005000,
+      360470069003001,
+      360470075003002,
+      360470065003000,
+      360470069002000,
+      360470069002001,
+      360470069003002,
+      360470075001003,
+      360470075004000
     ],
-    "zs:housing10":4346,
-    "zs:pop10":8744
-},
+    "zs:housing10": 4346,
+    "zs:pop10": 8744
+  },
   "bbox": [
     -74.00341402740526,
     40.67218,
     -73.978026,
     40.69157605287801
-],
-  "geometry": {"coordinates":[[[[-73.9799034495946,40.6874664498722],[-73.978026,40.68486400000015],[-73.97803319361323,40.68485332773921],[-73.9800505512349,40.68186042747897],[-73.98871200000001,40.68522400000028],[-73.98913989974679,40.68459424183705],[-73.99459562938203,40.67657171528715],[-73.99646022679832,40.67745698563853],[-73.99896,40.67218],[-74.00341402740526,40.67970501084065],[-74.000891,40.6853],[-73.998631,40.68992],[-73.99863700000012,40.69037600000014],[-73.9988450000001,40.690467],[-73.99925396324878,40.69157605287801],[-73.99236806986494,40.68969111722902],[-73.99201190769718,40.69043173904578],[-73.991742,40.6909930000002],[-73.98619630683604,40.6889991932962],[-73.98585403059606,40.68960223306223],[-73.9799034495946,40.6874664498722]]]],"type":"MultiPolygon"}
+  ],
+  "geometry": {"coordinates":[[[[-73.9799034495946,40.6874664498722],[-73.978026,40.68486400000015],[-73.97803319361323,40.68485332773921],[-73.9800505512349,40.68186042747897],[-73.988712,40.68522400000028],[-73.98913989974679,40.68459424183705],[-73.99459562938203,40.67657171528715],[-73.99646022679832,40.67745698563853],[-73.99896,40.67218],[-74.00341402740526,40.67970501084065],[-74.000891,40.6853],[-73.998631,40.68992],[-73.99863700000012,40.69037600000014],[-73.9988450000001,40.690467],[-73.99925396324878,40.69157605287801],[-73.99236806986494,40.68969111722902],[-73.99201190769718,40.69043173904578],[-73.991742,40.6909930000002],[-73.98619630683604,40.6889991932962],[-73.98585403059606,40.68960223306223],[-73.9799034495946,40.6874664498722]]]],"type":"MultiPolygon"}
 }


### PR DESCRIPTION
This PR updates the label position on the BoCoCa macrohood record and updates the `src:lbl_centroid` property value to reflect the mapshaper source. The new label position is roughly around Douglass & Court.

![Screenshot 2024-07-22 at 22 30 47](https://github.com/user-attachments/assets/69bc1667-e09f-4790-a4fc-e241aeb8b88e)

If this label is better left off the map, perhaps the hierarchy label property should be set to 0..?

**Number of records updated**: 1