### PR TITLE
Update geometries using existing label centroids

### DIFF
--- a/data/102/525/173/102525173.geojson
+++ b/data/102/525/173/102525173.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-76.56941,40.43481,-76.56941,40.43481",
+    "geom:latitude":40.43481,
+    "geom:longitude":-76.56941,
     "gn:elevation":149,
     "iso:country":"US",
     "lbl:latitude":40.43481,
@@ -27,7 +27,7 @@
         "Muir AAF"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -36,11 +36,11 @@
         "state_id":2347597
     },
     "wof:belongsto":[
-        85688481,
         85633793,
-        101719381,
         102081341,
-        85826915
+        101719381,
+        85826915,
+        85688481
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -51,7 +51,7 @@
         "icao:code":"KMUI"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"b774ef8c9e171b728dae1258d762711f",
     "wof:hierarchy":[
         {
             "campus_id":102525173,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102525173,
-    "wof:lastmodified":1589219004,
+    "wof:lastmodified":1730349150,
     "wof:name":"Muir Army Air Field",
     "wof:parent_id":85826915,
     "wof:placetype":"campus",
@@ -75,10 +75,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -76.56941,
+    40.43481,
+    -76.56941,
+    40.43481
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-76.56941,40.43481],"type":"Point"}
 }

--- a/data/102/525/213/102525213.geojson
+++ b/data/102/525/213/102525213.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-115.86561,43.04963,-115.86561,43.04963",
+    "geom:latitude":43.04963,
+    "geom:longitude":-115.86561,
     "gn:elevation":912,
     "gn:population":3238,
     "iso:country":"US",
@@ -66,7 +66,7 @@
         "Mountain Home Air Force Base CDP"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "src:population":"geonames",
     "woe:hierarchy":{
@@ -77,9 +77,9 @@
     },
     "wof:belongsto":[
         85633793,
+        102086075,
         85938211,
-        85688657,
-        102086075
+        85688657
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -92,7 +92,7 @@
         "wk:page":"Mountain Home Air Force Base"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"4649f5fbf9c9763720de31b036384ed5",
     "wof:hierarchy":[
         {
             "campus_id":102525213,
@@ -103,7 +103,7 @@
         }
     ],
     "wof:id":102525213,
-    "wof:lastmodified":1589219004,
+    "wof:lastmodified":1730349150,
     "wof:name":"Mountain Home Air Force Base",
     "wof:parent_id":85938211,
     "wof:placetype":"campus",
@@ -117,10 +117,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -115.86561,
+    43.04963,
+    -115.86561,
+    43.04963
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-115.86561,43.04963],"type":"Point"}
 }

--- a/data/102/525/731/102525731.geojson
+++ b/data/102/525/731/102525731.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-95.35922,35.66126,-95.35922,35.66126",
+    "geom:latitude":35.66126,
+    "geom:longitude":-95.35922,
     "gn:elevation":181,
     "iso:country":"US",
     "lbl:latitude":35.66126,
@@ -25,7 +25,7 @@
         "KMKO"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -35,9 +35,9 @@
     },
     "wof:belongsto":[
         85633793,
+        102083313,
         101715429,
-        85688585,
-        102083313
+        85688585
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -48,7 +48,7 @@
         "icao:code":"KMKO"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"7ff2f5214185cca9673a4a105e862889",
     "wof:hierarchy":[
         {
             "campus_id":102525731,
@@ -59,7 +59,7 @@
         }
     ],
     "wof:id":102525731,
-    "wof:lastmodified":1589219004,
+    "wof:lastmodified":1730349150,
     "wof:name":"Davis Field Airport",
     "wof:parent_id":101715429,
     "wof:placetype":"campus",
@@ -71,10 +71,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -95.35922,
+    35.66126,
+    -95.35922,
+    35.66126
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-95.35921999999999,35.66126],"type":"Point"}
 }

--- a/data/102/527/545/102527545.geojson
+++ b/data/102/527/545/102527545.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-108.79178,35.08323,-108.79178,35.08323",
+    "geom:latitude":35.08323,
+    "geom:longitude":-108.79178,
     "gn:elevation":1965,
     "iso:country":"US",
     "lbl:latitude":35.08323,
@@ -34,7 +34,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0411\u043b\u0435\u043a \u0420\u043e\u043a"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":292,
     "woe:hierarchy":{
@@ -45,9 +45,9 @@
     },
     "wof:belongsto":[
         85633793,
+        102081579,
         85977461,
-        85688493,
-        102081579
+        85688493
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -59,7 +59,7 @@
         "wk:page":"Black Rock Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"68d1bb840f5035fdd357a8d3f5b26251",
     "wof:hierarchy":[
         {
             "campus_id":102527545,
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":102527545,
-    "wof:lastmodified":1589219002,
+    "wof:lastmodified":1730349150,
     "wof:name":"Black Rock Airport",
     "wof:parent_id":85977461,
     "wof:placetype":"campus",
@@ -82,10 +82,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -108.79178,
+    35.08323,
+    -108.79178,
+    35.08323
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-108.79178,35.08323],"type":"Point"}
 }

--- a/data/102/527/981/102527981.geojson
+++ b/data/102/527/981/102527981.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-121.1039,38.48757,-121.1039,38.48757",
+    "geom:latitude":38.48757,
+    "geom:longitude":-121.1039,
     "gn:elevation":43,
     "iso:country":"US",
     "lbl:latitude":38.48757,
@@ -25,7 +25,7 @@
         "KRIU"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":207,
     "woe:hierarchy":{
@@ -36,9 +36,9 @@
     },
     "wof:belongsto":[
         85633793,
+        102082889,
         85926883,
-        85688637,
-        102082889
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -50,7 +50,7 @@
         "wk:page":"Rancho Murieta Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"3d63931619a34545e556a6bd756551b8",
     "wof:hierarchy":[
         {
             "campus_id":102527981,
@@ -61,7 +61,7 @@
         }
     ],
     "wof:id":102527981,
-    "wof:lastmodified":1589219002,
+    "wof:lastmodified":1730349150,
     "wof:name":"Rancho Murieta Airport",
     "wof:parent_id":85926883,
     "wof:placetype":"campus",
@@ -73,10 +73,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -121.1039,
+    38.48757,
+    -121.1039,
+    38.48757
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-121.1039,38.48757],"type":"Point"}
 }

--- a/data/102/528/473/102528473.geojson
+++ b/data/102/528/473/102528473.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-117.40997,33.9894,-117.40997,33.9894",
+    "geom:latitude":33.9894,
+    "geom:longitude":-117.40997,
     "gn:elevation":231,
     "iso:country":"US",
     "lbl:latitude":33.9894,
@@ -31,7 +31,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0444\u043b\u0431\u043e\u0431"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":314,
     "woe:hierarchy":{
@@ -42,11 +42,11 @@
         "suburb_id":55806878
     },
     "wof:belongsto":[
-        85688637,
         85633793,
-        85923319,
         102086221,
-        85873349
+        85923319,
+        85873349,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -58,7 +58,7 @@
         "wk:page":"Flabob Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"5e9616a437166db09554de80069e4561",
     "wof:hierarchy":[
         {
             "campus_id":102528473,
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":102528473,
-    "wof:lastmodified":1589219002,
+    "wof:lastmodified":1730349150,
     "wof:name":"Flabob Airport",
     "wof:parent_id":85873349,
     "wof:placetype":"campus",
@@ -82,10 +82,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -117.40997,
+    33.9894,
+    -117.40997,
+    33.9894
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-117.40997,33.9894],"type":"Point"}
 }

--- a/data/102/529/199/102529199.geojson
+++ b/data/102/529/199/102529199.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-82.62837,27.7641,-82.62837,27.7641",
+    "geom:latitude":27.7641,
+    "geom:longitude":-82.62837,
     "gn:elevation":2,
     "iso:country":"US",
     "lbl:latitude":27.7641,
@@ -34,7 +34,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043e\u043b\u0431\u0438\u0440\u0442 \u0432\u04b3\u0438\u0442\u0434"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":2143,
     "woe:hierarchy":{
@@ -45,11 +45,11 @@
         "suburb_id":55862520
     },
     "wof:belongsto":[
-        85688651,
         85633793,
-        85931833,
         102085759,
-        85880555
+        85931833,
+        85880555,
+        85688651
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -61,7 +61,7 @@
         "wk:page":"Albert Whitted Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"1dad750b54273ddd716116ddd6083bc6",
     "wof:hierarchy":[
         {
             "campus_id":102529199,
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":102529199,
-    "wof:lastmodified":1589219003,
+    "wof:lastmodified":1730349150,
     "wof:name":"Albert Whitted Airport",
     "wof:parent_id":85880555,
     "wof:placetype":"campus",
@@ -85,10 +85,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -82.62837,
+    27.7641,
+    -82.62837,
+    27.7641
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-82.62837,27.7641],"type":"Point"}
 }

--- a/data/102/530/053/102530053.geojson
+++ b/data/102/530/053/102530053.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-75.01045,40.08178,-75.01045,40.08178",
+    "geom:latitude":40.08178,
+    "geom:longitude":-75.01045,
     "gn:elevation":32,
     "iso:country":"US",
     "lbl:latitude":40.08178,
@@ -35,7 +35,7 @@
         "Aeroporto do Nordeste de Filad\u00e9lfia"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":895,
     "woe:hierarchy":{
@@ -46,11 +46,11 @@
         "suburb_id":55864648
     },
     "wof:belongsto":[
-        85688481,
         85633793,
-        101718083,
         102081353,
-        85803091
+        101718083,
+        85803091,
+        85688481
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -62,7 +62,7 @@
         "wk:page":"Northeast Philadelphia Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"2099fcf026bf612500301f562f5f7683",
     "wof:hierarchy":[
         {
             "campus_id":102530053,
@@ -74,7 +74,7 @@
         }
     ],
     "wof:id":102530053,
-    "wof:lastmodified":1589219003,
+    "wof:lastmodified":1730349150,
     "wof:name":"Northeast Philadelphia Airport",
     "wof:parent_id":85803091,
     "wof:placetype":"campus",
@@ -86,10 +86,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -75.01045,
+    40.08178,
+    -75.01045,
+    40.08178
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-75.01045000000001,40.08178],"type":"Point"}
 }

--- a/data/102/530/103/102530103.geojson
+++ b/data/102/530/103/102530103.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-76.30439,36.92515,-76.30439,36.92515",
+    "geom:latitude":36.92515,
+    "geom:longitude":-76.30439,
     "gn:elevation":3,
     "iso:country":"US",
     "lbl:latitude":36.92515,
@@ -25,7 +25,7 @@
         "KNGU"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -35,11 +35,11 @@
         "suburb_id":2449716
     },
     "wof:belongsto":[
-        85688747,
         85633793,
-        101728769,
         102085935,
-        85851637
+        101728769,
+        85851637,
+        85688747
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -50,7 +50,7 @@
         "icao:code":"KNGU"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"cc8c985729727711e3e31fa53ea32531",
     "wof:hierarchy":[
         {
             "campus_id":102530103,
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":102530103,
-    "wof:lastmodified":1589219003,
+    "wof:lastmodified":1730349150,
     "wof:name":"Norfolk Naval Air Station",
     "wof:parent_id":85851637,
     "wof:placetype":"campus",
@@ -74,10 +74,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -76.30439,
+    36.92515,
+    -76.30439,
+    36.92515
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-76.30439,36.92515],"type":"Point"}
 }

--- a/data/102/530/159/102530159.geojson
+++ b/data/102/530/159/102530159.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-110.84981,31.41649,-110.84981,31.41649",
+    "geom:latitude":31.41649,
+    "geom:longitude":-110.84981,
     "gn:elevation":1184,
     "iso:country":"US",
     "lbl:latitude":31.41649,
@@ -31,7 +31,7 @@
         "Paloma International Airport"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":316,
     "woe:hierarchy":{
@@ -54,7 +54,7 @@
         "wk:page":"Nogales International Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"4ba8a6de4acd8808dcaaacdb2c8385df",
     "wof:hierarchy":[
         {
             "campus_id":102530159,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":102530159,
-    "wof:lastmodified":1589219003,
+    "wof:lastmodified":1730349150,
     "wof:name":"Nogales International Airport",
     "wof:parent_id":85688719,
     "wof:placetype":"campus",
@@ -75,10 +75,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -110.84981,
+    31.41649,
+    -110.84981,
+    31.41649
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-110.84981000000001,31.41649],"type":"Point"}
 }

--- a/data/102/531/065/102531065.geojson
+++ b/data/102/531/065/102531065.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-101.33914,48.42087,-101.33914,48.42087",
+    "geom:latitude":48.42087,
+    "geom:longitude":-101.33914,
     "gn:elevation":494,
     "gn:population":5521,
     "iso:country":"US",
@@ -29,7 +29,7 @@
         "Minot Air Force Base CDP"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "src:population":"geonames",
     "wd:wordcount":4330,
@@ -41,9 +41,9 @@
     },
     "wof:belongsto":[
         85633793,
+        102082117,
         85982739,
-        85688525,
-        102082117
+        85688525
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
         "qs_pg:id":357121
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"8342ce8cfbaff2acaae480b873d067ab",
     "wof:hierarchy":[
         {
             "campus_id":102531065,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":102531065,
-    "wof:lastmodified":1589219003,
+    "wof:lastmodified":1730349150,
     "wof:name":"Minot Air Force Base",
     "wof:parent_id":85982739,
     "wof:placetype":"campus",
@@ -80,10 +80,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -101.33914,
+    48.42087,
+    -101.33914,
+    48.42087
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-101.33914,48.42087],"type":"Point"}
 }

--- a/data/102/532/245/102532245.geojson
+++ b/data/102/532/245/102532245.geojson
@@ -8,9 +8,9 @@
     "edtf:superseded":"2018-08-15",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-93.60822,45.55987,-93.60822,45.55987",
+    "geom:latitude":45.55987,
+    "geom:longitude":-93.60822,
     "gn:elevation":298,
     "iso:country":"US",
     "lbl:latitude":45.55987,
@@ -31,7 +31,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u0448\u0430\u04b3\u0440\u0435 \u043f\u0440\u0438\u043d\u0441\u0442\u043d"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":323,
     "woe:hierarchy":{
@@ -42,9 +42,9 @@
     },
     "wof:belongsto":[
         85633793,
+        102087761,
         85968823,
-        85688727,
-        102087761
+        85688727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -56,7 +56,7 @@
         "wk:page":"Princeton Municipal Airport (Minnesota)"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"932bc7e36253e7dd22f434a0e07178bd",
     "wof:hierarchy":[
         {
             "campus_id":102532245,
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":102532245,
-    "wof:lastmodified":1589219002,
+    "wof:lastmodified":1730349150,
     "wof:name":"Princeton Municipal Airport",
     "wof:parent_id":85968823,
     "wof:placetype":"campus",
@@ -81,10 +81,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -93.60822,
+    45.55987,
+    -93.60822,
+    45.55987
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-93.60822,45.55987],"type":"Point"}
 }

--- a/data/102/532/295/102532295.geojson
+++ b/data/102/532/295/102532295.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-93.19167,31.04483,-93.19167,31.04483",
+    "geom:latitude":31.04483,
+    "geom:longitude":-93.19167,
     "gn:elevation":100,
     "iso:country":"US",
     "lbl:latitude":31.04483,
@@ -24,7 +24,7 @@
         "POE"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "iata:code":"POE"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"11e17e68f701bc9752fd90a859dc5aeb",
     "wof:hierarchy":[
         {
             "campus_id":102532295,
@@ -52,7 +52,7 @@
         }
     ],
     "wof:id":102532295,
-    "wof:lastmodified":1589219002,
+    "wof:lastmodified":1730349150,
     "wof:name":"Polk Army Air Field",
     "wof:parent_id":85688735,
     "wof:placetype":"campus",
@@ -64,10 +64,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -93.19167,
+    31.04483,
+    -93.19167,
+    31.04483
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-93.19167,31.04483],"type":"Point"}
 }

--- a/data/102/532/625/102532625.geojson
+++ b/data/102/532/625/102532625.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-72.64958,41.74119,-72.64958,41.74119",
+    "geom:latitude":41.74119,
+    "geom:longitude":-72.64958,
     "gn:elevation":5,
     "iso:country":"US",
     "lbl:latitude":41.74119,
@@ -34,7 +34,7 @@
         "Brainard Airport"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":270,
     "woe:hierarchy":{
@@ -45,11 +45,11 @@
         "suburb_id":55859595
     },
     "wof:belongsto":[
-        85688629,
         85633793,
-        85930819,
         102085381,
-        85878029
+        85930819,
+        85878029,
+        85688629
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -61,7 +61,7 @@
         "wk:page":"Hartford\u2013Brainard Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"d4e738edaa80b2637bbfcbef9c649ffa",
     "wof:hierarchy":[
         {
             "campus_id":102532625,
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":102532625,
-    "wof:lastmodified":1589219002,
+    "wof:lastmodified":1730349150,
     "wof:name":"Hartford-Brainard Airport",
     "wof:parent_id":85878029,
     "wof:placetype":"campus",
@@ -85,10 +85,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -72.64958,
+    41.74119,
+    -72.64958,
+    41.74119
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-72.64958,41.74119],"type":"Point"}
 }

--- a/data/102/533/641/102533641.geojson
+++ b/data/102/533/641/102533641.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-101.20351,30.73147,-101.20351,30.73147",
+    "geom:latitude":30.73147,
+    "geom:longitude":-101.20351,
     "gn:elevation":720,
     "iso:country":"US",
     "lbl:latitude":30.73147,
@@ -24,7 +24,7 @@
         "OZA"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -43,7 +43,7 @@
         "iata:code":"OZA"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"a18321047731b110583eeb0343066195",
     "wof:hierarchy":[
         {
             "campus_id":102533641,
@@ -52,7 +52,7 @@
         }
     ],
     "wof:id":102533641,
-    "wof:lastmodified":1589219002,
+    "wof:lastmodified":1730349150,
     "wof:name":"Ozona Municipal Airport",
     "wof:parent_id":85688753,
     "wof:placetype":"campus",
@@ -64,10 +64,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -101.20351,
+    30.73147,
+    -101.20351,
+    30.73147
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-101.20350999999999,30.73147],"type":"Point"}
 }

--- a/data/102/533/665/102533665.geojson
+++ b/data/102/533/665/102533665.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-87.90058,42.11662,-87.90058,42.11662",
+    "geom:latitude":42.11662,
+    "geom:longitude":-87.90058,
     "gn:elevation":192,
     "iso:country":"US",
     "lbl:latitude":42.11662,
@@ -27,7 +27,7 @@
         "Palwaukee Municipal Airport"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424977,
@@ -36,11 +36,11 @@
         "state_id":2347572
     },
     "wof:belongsto":[
-        85688697,
         85633793,
-        85938409,
         102084317,
-        85891073
+        85938409,
+        85891073,
+        85688697
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -52,7 +52,7 @@
         "wk:page":"Chicago Executive Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"2b0a14c38cf0ca4c16e8e04158e97150",
     "wof:hierarchy":[
         {
             "campus_id":102533665,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":102533665,
-    "wof:lastmodified":1589219002,
+    "wof:lastmodified":1730349150,
     "wof:name":"Pal Waukee Airport",
     "wof:parent_id":85891073,
     "wof:placetype":"campus",
@@ -76,10 +76,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -87.90058,
+    42.11662,
+    -87.90058,
+    42.11662
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-87.90058000000001,42.11662],"type":"Point"}
 }

--- a/data/102/533/669/102533669.geojson
+++ b/data/102/533/669/102533669.geojson
@@ -6,9 +6,9 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"0.0,0.0,0.0,0.0",
-    "geom:latitude":0.0,
-    "geom:longitude":0.0,
+    "geom:bbox":"-119.20789,34.20056,-119.20789,34.20056",
+    "geom:latitude":34.20056,
+    "geom:longitude":-119.20789,
     "gn:elevation":11,
     "iso:country":"US",
     "lbl:latitude":34.20056,
@@ -34,7 +34,7 @@
         "\u0424\u0443\u0440\u0443\u0434\u0433\u043e\u04b3\u0438 \u043e\u0432\u043a\u0441\u043d\u043e\u0440\u0434"
     ],
     "src:centroid_lbl":"geonames",
-    "src:geom":"unknown",
+    "src:geom":"geonames",
     "src:geom_alt":[],
     "wd:wordcount":1070,
     "woe:hierarchy":{
@@ -45,11 +45,11 @@
         "suburb_id":55860912
     },
     "wof:belongsto":[
-        85688637,
         85633793,
-        85923231,
         102086933,
-        85879657
+        85923231,
+        85879657,
+        85688637
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -61,7 +61,7 @@
         "wk:page":"Oxnard Airport"
     },
     "wof:country":"US",
-    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
+    "wof:geomhash":"c4897be968aec4b801a8fabf61fba53c",
     "wof:hierarchy":[
         {
             "campus_id":102533669,
@@ -73,7 +73,7 @@
         }
     ],
     "wof:id":102533669,
-    "wof:lastmodified":1589219001,
+    "wof:lastmodified":1730349150,
     "wof:name":"Oxnard Airport",
     "wof:parent_id":85879657,
     "wof:placetype":"campus",
@@ -85,10 +85,10 @@
     ]
 },
   "bbox": [
-    0.0,
-    0.0,
-    0.0,
-    0.0
+    -119.20789,
+    34.20056,
+    -119.20789,
+    34.20056
 ],
-  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
+  "geometry": {"coordinates":[-119.20789000000001,34.20056],"type":"Point"}
 }


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/2216.

This PR adds geometries to a handful of airport campus records. These records' existing GeoNames-sources label centroids were used to construct the new geometries. Source properties are updated to reference GeoNames, too.

No PIP work needed, as none of these records have descendants. And no alt geometry files are included here since the existing geometries are null.

Number of records updated: 17