### PR TITLE
Fix concordances for Brooklyn, Ohio and Brooklyn, New York

### DIFF
--- a/data/101/712/549/101712549.geojson
+++ b/data/101/712/549/101712549.geojson
@@ -316,7 +316,7 @@
     "wof:concordances":{
         "fct:id":"08d085c2-8f76-11e1-848f-cfd5bf3ef515",
         "fips:code":"3909246",
-        "gn:id":5110302,
+        "gn:id":5148346,
         "gp:id":2369963,
         "qs_pg:id":432064,
         "uscensus:geoid":"3909246",
@@ -324,7 +324,6 @@
         "wk:page":"Brooklyn, Ohio"
     },
     "wof:concordances_alt":{
-        "gn:id":5148346,
         "qs_pg:id":1157574
     },
     "wof:concordances_official":"uscensus:geoid",

--- a/data/421/205/765/421205765.geojson
+++ b/data/421/205/765/421205765.geojson
@@ -424,6 +424,7 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "gn:id":5110302,
         "wd:id":"Q18419"
     },
     "wof:country":"US",


### PR DESCRIPTION
Somehow, the WOF record for [Brooklyn, OH - 101712549](https://spelunker.whosonfirst.org/id/101712549) ended up with a concordance to [Geonames record 5110302 - Brooklyn, NY](https://www.geonames.org/5110302/brooklyn.html).

This PR fixes the concordance and also adds a proper concordance for the actual WOF and GN Brooklyn, NY records.